### PR TITLE
setuptools script don't copy templates, fix for that

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,12 @@ setup(name='pyramid_debugtoolbar',
       license="BSD",
       packages=find_packages(),
       include_package_data=True,
+      package_data={
+          'pyramid_debugtoolbar.panels': [
+              '*.jinja2',
+              'templates/*'
+          ],
+      },
       zip_safe=False,
       install_requires=install_requires,
       tests_require=install_requires,


### PR DESCRIPTION
$ python2.7 setup.py build
...
copying pyramid_debugtoolbar/panels/templates/headers.jinja2 -> build/lib/pyramid_debugtoolbar/panels/templates
copying pyramid_debugtoolbar/panels/templates/logger.jinja2 -> build/lib/pyramid_debugtoolbar/panels/templates
copying pyramid_debugtoolbar/panels/templates/performance.jinja2 -> build/lib/pyramid_debugtoolbar/panels/templates
...
