### PR TITLE
Fixed IE7 rendering of the Toolbar

### DIFF
--- a/pyramid_debugtoolbar/static/css/toolbar.css
+++ b/pyramid_debugtoolbar/static/css/toolbar.css
@@ -55,8 +55,8 @@
 	width:auto;
 }
 
-#pDebug #pDebugToolbar li>a,
-#pDebug #pDebugToolbar li>div.contentless  {
+#pDebug #pDebugToolbar li a,
+#pDebug #pDebugToolbar li div.contentless  {
 	font-weight:normal;
 	font-style:normal;
 	text-decoration:none;
@@ -68,6 +68,12 @@
 
 #pDebug #pDebugToolbar li>div.contentless  {
 	color: #383838;
+}
+
+#pDebug #pDebugToolbar li,
+#pDebug #pDebugToolbar a {
+	display: inline-block;
+	width: 100%;
 }
 
 #pDebug #pDebugToolbar li a:hover {


### PR DESCRIPTION
I Tested in IE7

and regression tested in:

FF
Safari
Chrome

I didn't see any regressions in the styling for the toolbar.  Still needs to be tested in IE8 - IE9 however I don't have access to those browsers.
