### PR TITLE
Fixed toolbar demo rendering in IE7 and IE8

### DIFF
--- a/demo/templates/index.mako
+++ b/demo/templates/index.mako
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE html>
 <html>
     <head>
         <title>${title}</title>


### PR DESCRIPTION
Updated demo doctype to html5 style doctype to trigger correct rendering mode

Tested in IE7, IE8, FF, Chrome and Safari
