### PR TITLE
Fix for KeyError exception

### DIFF
--- a/demo/demo.py
+++ b/demo/demo.py
@@ -31,7 +31,7 @@ def notfound(request):
 def test_page(request):
     title = 'Pyramid Debugtoolbar'
     log.info(title)
-    return {'title': title}
+    return {'title': title, 'show_sqla_link': bool(sqlalchemy)}
 
 @view_config(route_name='test_redirect')
 def test_redirect(request):

--- a/demo/templates/index.mako
+++ b/demo/templates/index.mako
@@ -14,9 +14,11 @@
         <p>
           <a href="${request.route_url('test_notfound')}">Not found example</a>
         </p>
+	% if show_sqla_link:
         <p>
           <a href="${request.route_url('test_sqla')}">SQLAlchemy example</a>
         </p>
+	% endif
         <p>
           <a href="${request.route_url('test_chameleon_exc')}">Chameleon Exception example</a>
         </p>


### PR DESCRIPTION
show SQLAlchemy example link only when sqlalchemy is used, prevents KeyError exception in mako template
