### PR TITLE
Issue #36: Prevent settings.jinja2 from raising a UnicodeDecodeError if s

### DIFF
--- a/pyramid_debugtoolbar/panels/settings.py
+++ b/pyramid_debugtoolbar/panels/settings.py
@@ -50,8 +50,15 @@ class SettingsDebugPanel(DebugPanel):
 
     def content(self):
         vars = {
-            'settings': self.settings
+            'settings': [(k, decode_safely(v)) for k, v in self.settings]
         }
         return self.render(
             'pyramid_debugtoolbar.panels:templates/settings.jinja2',
             vars, self.request)
+
+
+def decode_safely(x):
+    try:
+        return x.decode('utf-8', 'replace')
+    except AttributeError:
+        return x


### PR DESCRIPTION
Issue #36: Prevent settings.jinja2 from raising a UnicodeDecodeError if settings contains non-ascii values such as those created by os.urandom().
