### PR TITLE
Fix for problems with non-ascii exception messages

### DIFF
--- a/pyramid_debugtoolbar/compat.py
+++ b/pyramid_debugtoolbar/compat.py
@@ -21,25 +21,45 @@ else:
 
 # TODO check if errors is ever used
 
-def text_(s, encoding='latin-1', errors='strict'):
+def text_(s, encoding=None, errors='strict'):
     if isinstance(s, binary_type):
+        if not encoding:
+            try:
+                return s.decode('utf-8')
+            except UnicodeDecodeError:
+                encoding = 'latin-1'
         return s.decode(encoding, errors)
     return s # pragma: no cover
 
-def bytes_(s, encoding='latin-1', errors='strict'):
+def bytes_(s, encoding=None, errors='strict'):
     if isinstance(s, text_type): # pragma: no cover
+        if not encoding:
+            try:
+                return s.encode('latin-1')
+            except UnicodeEncodeError:
+                encoding = 'utf-8'
         return s.encode(encoding, errors)
     return s
 
 if PY3: # pragma: no cover
-    def native_(s, encoding='latin-1', errors='strict'):
+    def native_(s, encoding=None, errors='strict'):
         if isinstance(s, text_type):
             return s
+        if not encoding:
+            try:
+                return str(s, 'utf-8')
+            except UnicodeDecodeError:
+                encoding = 'latin-1'
         return str(s, encoding, errors)
 else:
-    def native_(s, encoding='latin-1', errors='strict'):
+    def native_(s, encoding=None, errors='strict'):
         if isinstance(s, text_type): # pragma: no cover
             return s.encode(encoding, errors)
+        if not encoding:
+            try:
+                return s.encode('latin-1')
+            except UnicodeEncodeError:
+                encoding = 'utf-8'
         return str(s)
 
 if PY3: # pragma: no cover
@@ -124,7 +144,7 @@ if PY3: # pragma: no cover
     xrange_ = range
 else:
     xrange_ = xrange
-    
+
 
 if PY3: # pragma: no cover
     def iteritems_(d):

--- a/pyramid_debugtoolbar/tbtools.py
+++ b/pyramid_debugtoolbar/tbtools.py
@@ -218,15 +218,15 @@ class Traceback(object):
             ))
 
         if self.is_syntax_error:
-            description_wrapper = text_('<pre class=syntaxerror>%s</pre>')
+            description_wrapper = '<pre class=syntaxerror>%s</pre>'
         else:
-            description_wrapper = text_('<blockquote>%s</blockquote>')
+            description_wrapper = '<blockquote>%s</blockquote>'
 
         vars = {
             'classes':      text_(' '.join(classes)),
             'title':        title and text_('<h3>%s</h3>' % title) or text_(''),
             'frames':       text_('\n'.join(frames)),
-            'description':  description_wrapper % escape(self.exception),
+            'description':  text_(description_wrapper % escape(self.exception)),
         }
         return render('pyramid_debugtoolbar:templates/exception_summary.mako',
                       vars, request=request)
@@ -235,7 +235,7 @@ class Traceback(object):
         """Render the Full HTML page with the traceback info."""
         static_path = request.static_url(STATIC_PATH)
         root_path = request.route_url(ROOT_ROUTE_NAME)
-        exc = escape(self.exception)
+        exc = text_(escape(self.exception))
         summary = self.render_summary(include_title=False, request=request)
         qs = {'token':request.exc_history.token, 'tb':str(self.id)}
         url = request.route_url(EXC_ROUTE_NAME, _query=qs)
@@ -269,7 +269,7 @@ class Traceback(object):
                 frame.function_name
             ))
             yield text_('    ' + frame.current_line.strip())
-        yield self.exception
+        yield text_(self.exception)
 
     @reify
     def plaintext(self):

--- a/pyramid_debugtoolbar/templates/console.mako
+++ b/pyramid_debugtoolbar/templates/console.mako
@@ -2,13 +2,14 @@
   "http://www.w3.org/TR/html4/loose.dtd">
 <html>
   <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>${title} // Werkzeug Debugger</title>
-    <link rel="stylesheet" href="${static_path}css/debugger.css" 
+    <link rel="stylesheet" href="${static_path}css/debugger.css"
           type="text/css">
-    <script type="text/javascript" 
+    <script type="text/javascript"
             src="${static_path}js/jquery-1.6.4.min.js"></script>
     <script type="text/javascript">var jq = jQuery.noConflict(true);</script>
-    <script type="text/javascript" 
+    <script type="text/javascript"
             src="${static_path}js/debugger.js"></script>
     <script type="text/javascript">
       var TRACEBACK = ${traceback_id},

--- a/pyramid_debugtoolbar/templates/exception.mako
+++ b/pyramid_debugtoolbar/templates/exception.mako
@@ -3,13 +3,14 @@
 
 <html>
   <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>${title} // Werkzeug Debugger</title>
-    <link rel="stylesheet" href="${static_path}css/debugger.css" 
+    <link rel="stylesheet" href="${static_path}css/debugger.css"
           type="text/css">
-    <script type="text/javascript" 
+    <script type="text/javascript"
           src="${static_path}js/jquery-1.6.4.min.js"></script>
     <script type="text/javascript">var jq = jQuery.noConflict(true);</script>
-    <script type="text/javascript" 
+    <script type="text/javascript"
           src="${static_path}js/debugger.js"></script>
     <script type="text/javascript">
       var TRACEBACK = ${traceback_id},
@@ -34,10 +35,10 @@
         <input type="hidden" name="language" value="pytb">
           This is the Copy/Paste friendly version of the traceback.
         </p>
-        <textarea cols="50" rows="10" name="code" 
+        <textarea cols="50" rows="10" name="code"
                   readonly>${plaintext}</textarea>
       </div>
-      
+
     <div class="explanation">
       <p>
         <b>Warning: this feature should not be enabled on production
@@ -46,27 +47,27 @@
 
       % if evalex:
       <p>
-        
+
         Hover over any gray area in the traceback and click on the
         <img src="${static_path}img/console.png"/> icon on the right hand
         side of that gray area to show an interactive console for the
         associated frame.  Type arbitrary Python into the console; it will be
         evaluated in the context of the associated frame.  In the interactive
         console there are helpers available for introspection:
-        
+
         <ul>
           <li><code>dump()</code> shows all variables in the frame
           <li><code>dump(obj)</code> dumps all that's known about the object
         </ul>
       </p>
       % endif
-      
+
       <p>
-        Hover over any gray area in the traceback and click on 
-        <img src="${static_path}img/source.png"/> on the right hand side 
+        Hover over any gray area in the traceback and click on
+        <img src="${static_path}img/source.png"/> on the right hand side
         of that gray area to show the source of the file associated with the frame.
       </p>
-      
+
       <p>
         Click on the traceback header to switch back and forth between the
         rendered version of the traceback and a plaintext copy-paste-friendly
@@ -77,18 +78,18 @@
         URL to recover this traceback page: <a href="${url}">${url}</a>
       </p>
     </div>
-    
+
     <div class="footer">
       Brought to you by <strong class="arthur">DONT PANIC</strong>, your
       friendly Werkzeug powered traceback interpreter.
     </div>
     </div>
     <!--
-       
+
        ${plaintext_cs}
-       
+
       -->
-    
+
   </body>
-  
+
 </html>

--- a/pyramid_debugtoolbar/tests/test_utils.py
+++ b/pyramid_debugtoolbar/tests/test_utils.py
@@ -33,18 +33,19 @@ class Test_format_fname(unittest.TestCase):
 
     def test_unknown(self):
         val = '..' + os.path.sep + 'foo'
-        self.assertEqual(self._callFUT(val), './../foo')
+        self.assertEqual(self._callFUT(val), os.path.join('.', '..', 'foo'))
 
     def test_module_file_path(self):
+        root = os.path.sep
         sys_path = [
-            '/foo/',
-            '/foo/bar',
-            '/usr/local/python/site-packages/',
+            os.path.join(root, 'foo', ''),
+            os.path.join(root, 'foo', 'bar'),
+            os.path.join(root, 'usr', 'local', 'python', 'site-packages')
         ]
-        modpath = self._callFUT(
-            '/foo/bar/pyramid_debugtoolbar/tests/debugfoo.py', sys_path)
-        self.assertEqual(modpath, 
-            '<pyramid_debugtoolbar/tests/debugfoo.py>')
+        modpath = self._callFUT(os.path.join(root, 'foo', 'bar',
+            'pyramid_debugtoolbar', 'tests', 'debugfoo.py'), sys_path)
+        self.assertEqual(modpath, '<%s>' %
+            os.path.join('pyramid_debugtoolbar', 'tests', 'debugfoo.py'))
 
     def test_no_matching_sys_path(self):
         val = '/foo/bar/pyramid_debugtoolbar/foo.py'

--- a/pyramid_debugtoolbar/tests/test_views.py
+++ b/pyramid_debugtoolbar/tests/test_views.py
@@ -50,7 +50,7 @@ class TestExceptionDebugView(unittest.TestCase):
         request = self._makeRequest()
         request.params['token'] = 'wrong'
         self.assertRaises(HTTPBadRequest, self._makeOne, request)
-        
+
     def test_source(self):
         request = self._makeRequest()
         request.params['frm'] = '0'
@@ -163,6 +163,6 @@ class DummyConsole(object):
 class DummyFrame(object):
     def __init__(self):
         self.console = DummyConsole()
-        
+
     def render_source(self):
         return 'source'

--- a/pyramid_debugtoolbar/utils.py
+++ b/pyramid_debugtoolbar/utils.py
@@ -28,7 +28,7 @@ EXC_ROUTE_NAME = 'debugtoolbar.exception'
 def format_fname(value, _sys_path=None):
     if _sys_path is None:
         _sys_path = sys.path # dependency injection
-    # If the value is not an absolute path, the it is a builtin or
+    # If the value is not an absolute path, then it is a builtin or
     # a relative file (thus a project file).
     if not os.path.isabs(value):
         if value.startswith(('{', '<')):


### PR DESCRIPTION
For instance, PostgreSQL creates error messages in latin-1 or utf-8 depending on how it is configured. The debug toolbar assumes that error messages are always ascii strings or unicode and crashes with a UnicodeDecodeError on such exceptions. This patch makes the debug toolbar handle and display such exceptions properly.