### PR TITLE
Fixed a Python 3 issue from working with query['statement'] attribute

### DIFF
--- a/pyramid_debugtoolbar/panels/sqla.py
+++ b/pyramid_debugtoolbar/panels/sqla.py
@@ -45,7 +45,7 @@ try:
                 queries.append({
                     'engine_id': id(conn.engine),
                     'duration': stop_timer - conn.pdtb_start_timer,
-                    'statement': stmt,
+                    'statement': text(stmt),
                     'parameters': params,
                     'context': context
                 })


### PR DESCRIPTION
Line 96 would trigger a TypeError because stmt was bound to a bytes object rather than a str.