### PR TITLE
Enable tablesorter on SQLA queries table

### DIFF
--- a/pyramid_debugtoolbar/panels/templates/sqlalchemy.dbtmako
+++ b/pyramid_debugtoolbar/panels/templates/sqlalchemy.dbtmako
@@ -1,4 +1,4 @@
-<table id="pSqlaTable">
+<table id="pSqlaTable" class="pDebugSortable">
 	<thead>
 		<tr>
 			<th>Time&nbsp;(ms)</th>


### PR DESCRIPTION
That would be useful to sort queries by time
