### PR TITLE
Short term fix for preventing error when converting binary query params to json.

### DIFF
--- a/pyramid_debugtoolbar/panels/sqla.py
+++ b/pyramid_debugtoolbar/panels/sqla.py
@@ -99,6 +99,8 @@ class SQLADebugPanel(DebugPanel):
                 params = url_quote(json.dumps(query['parameters']))
             except TypeError:
                 pass # object not JSON serializable
+            except UnicodeDecodeError:
+                pass # parameters contain non-utf8 (probably binary) data
 
             need = self.request.exc_history.token + stmt + params
             hash = hashlib.sha1(bytes_(need)).hexdigest()


### PR DESCRIPTION
An error occurs when submitting a sqlalchemy query with binary data in the parameters.

In my specific example I was writing a new user with a hashed password that was binary.

This code demonstrates the underlying issue for me:

``` python
import hashlib
import json
json.dumps({'password': hashlib.sha1('a').digest()})
```

``` pythontraceback
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python2.7/json/__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
  File "/usr/lib/python2.7/json/encoder.py", line 201, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/lib/python2.7/json/encoder.py", line 264, in iterencode
    return _iterencode(o, 0)
UnicodeDecodeError: 'utf8' codec can't decode byte 0x86 in position 0: invalid start byte
```
