### PR TITLE
Document usage with RequireJS

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -59,6 +59,28 @@ console.
 .. note:: The HTML returned by your Pyramid application must contain a
    ``</body>`` end-body tag for the toolbar to be injected into a response.
 
+.. note:: The debug toolbar loads and uses RequireJS_ to load its scripts.
+   This fails if RequireJS is already loaded by your site.
+   To use the toolbar in this case, just add it to RequireJS's path configuration
+   and ask RequireJS to load it:
+
+   .. code-block:: javascript
+
+      require.config({
+        paths: {
+          "jquery": "jquery-1.7.2.min",
+          "toolbar": "/_debug_toolbar/static/js/toolbar"
+        }
+      });
+    
+      require(["jquery", "toolbar"], function($, toolbar) {
+        $(function() {
+          // your module
+        });
+      }); 
+
+.. _RequireJS: http://requirejs.org/
+
 Settings
 ~~~~~~~~
 


### PR DESCRIPTION
Instructions on how to use DBT on pages that already load RequireJS are hidden [in the changelog](https://github.com/Pylons/pyramid_debugtoolbar/blob/master/CHANGES.txt#L23). This pull request adds this to the main documentation.

Solves #78.
