### PR TITLE
Fix sqlalchemy query duration: from microseconds to milliseconds.

### DIFF
--- a/pyramid_debugtoolbar/panels/sqla.py
+++ b/pyramid_debugtoolbar/panels/sqla.py
@@ -42,9 +42,10 @@ try:
                 engines[id(conn.engine)] = weakref.ref(conn.engine)
                 setattr(request.registry, 'pdtb_sqla_engines', engines)
                 queries = getattr(request, 'pdtb_sqla_queries', [])
+                duration = (stop_timer - conn.pdtb_start_timer) * 1000
                 queries.append({
                     'engine_id': id(conn.engine),
-                    'duration': stop_timer - conn.pdtb_start_timer,
+                    'duration': duration,
                     'statement': stmt,
                     'parameters': params,
                     'context': context

--- a/pyramid_debugtoolbar/panels/templates/sqlalchemy.dbtmako
+++ b/pyramid_debugtoolbar/panels/templates/sqlalchemy.dbtmako
@@ -10,7 +10,7 @@
 	<tbody>
 	% for i, query in enumerate(queries):
 		<tr class="${i%2 and 'pDebugEven' or 'pDebugOdd'}">
-			<td>${'%.4f' % query['duration']}</td>
+			<td>${'%.2f' % query['duration']}</td>
 			<td>
 			% if query['params']:
 				% if query['is_select']:

--- a/pyramid_debugtoolbar/panels/templates/sqlalchemy_explain.dbtmako
+++ b/pyramid_debugtoolbar/panels/templates/sqlalchemy_explain.dbtmako
@@ -8,7 +8,7 @@
 			<dt>Executed SQL</dt>
 			<dd>${sql|n}</dd>
 			<dt>Time</dt>
-			<dd>${'%.4f' % (duration)} ms</dd>
+			<dd>${'%.2f' % (duration)} ms</dd>
 		</dl>
 		<table class="djSqlExplain">
 			<thead>

--- a/pyramid_debugtoolbar/panels/templates/sqlalchemy_select.dbtmako
+++ b/pyramid_debugtoolbar/panels/templates/sqlalchemy_select.dbtmako
@@ -8,7 +8,7 @@
 			<dt>Executed SQL</dt>
 			<dd>${sql|n}</dd>
 			<dt>Time</dt>
-			<dd>${'%.4f' % (duration)} ms</dd>
+			<dd>${'%.2f' % (duration)} ms</dd>
 		</dl>
 		% if result:
 		<table class="djSqlExplain">


### PR DESCRIPTION
At this time we can see in debugtoolbar sqlalchemy query table, that duration is calculated in `milliseconds` ( **ms** ), but in fact it is `microseconds`.
