### PR TITLE
Wrap long error messages

### DIFF
--- a/pyramid_debugtoolbar/static/css/debugger.css
+++ b/pyramid_debugtoolbar/static/css/debugger.css
@@ -14,6 +14,7 @@ div.debugger { text-align: left; padding: 12px; margin: auto;
                background-color: white; }
 h1           { font-size: 36px; margin: 0 0 0.3em 0; }
 div.detail p { margin: 0 0 8px 13px; font-size: 14px; }
+div.detail pre.errormsg { word-wrap: break-word; }
 div.explanation { margin: 20px 13px; font-size: 15px; color: #555; }
 div.footer   { font-size: 13px; text-align: right; margin: 30px 0;
                color: #999999; }


### PR DESCRIPTION
I have added a rule to debugger.css that sets the word-wrap property on div.detail pre.errormsg to break-line.  This will allow for breaking in the middle of long file paths.
