### PR TITLE
sqlalchemy: Don't double-encode raw_sql in URLs

### DIFF
--- a/pyramid_debugtoolbar/panels/templates/sqlalchemy.dbtmako
+++ b/pyramid_debugtoolbar/panels/templates/sqlalchemy.dbtmako
@@ -14,8 +14,8 @@
 			<td>
 			% if query['params']:
 				% if query['is_select']:
-				<a class="remoteCall" href="${root_path}/sqlalchemy/sql_select?sql=${query['raw_sql']|u}&amp;params=${query['params']}&amp;duration=${str(query['duration'])|u}&amp;hash=${query['hash']}&amp;engine_id=${str(query['engine_id'])|u}">SELECT</a><br />
-				<a class="remoteCall" href="${root_path}/sqlalchemy/sql_explain?sql=${query['raw_sql']|u}&amp;params=${query['params']}&amp;duration=${str(query['duration'])|u}&amp;hash=${query['hash']}&amp;engine_id=${str(query['engine_id'])|u}">EXPLAIN</a><br />
+				<a class="remoteCall" href="${root_path}/sqlalchemy/sql_select?sql=${query['raw_sql']|u,n}&amp;params=${query['params']}&amp;duration=${str(query['duration'])|u}&amp;hash=${query['hash']}&amp;engine_id=${str(query['engine_id'])|u}">SELECT</a><br />
+				<a class="remoteCall" href="${root_path}/sqlalchemy/sql_explain?sql=${query['raw_sql']|u,n}&amp;params=${query['params']}&amp;duration=${str(query['duration'])|u}&amp;hash=${query['hash']}&amp;engine_id=${str(query['engine_id'])|u}">EXPLAIN</a><br />
 				% endif
 			% endif
 			</td>


### PR DESCRIPTION
Use the "n" filter to disable default_filters when including the raw
SQL in links, leaving only the "u" filter (URL escaping).

SQLAlchemy double-quotes column names when they conflict with SQL
keywords, for example "order".

Since Pyramid sets mako.default_filters to ["h"], all Mako
${}-expressions are HTML-escaped unless the "n" filter is given.
This means that `${'"'}` will output `&#34;`, and `${'"'|u}`
will result in `%26%2334%3B`. `${'"'|u,n}` gives `%22` which is
what we need for the URL.
