### PR TITLE
Fix to handle non-ascii characters in platform version shown in Versions panel.

### DIFF
--- a/pyramid_debugtoolbar/panels/versions.py
+++ b/pyramid_debugtoolbar/panels/versions.py
@@ -1,24 +1,22 @@
 import sys
+import platform
 import pkg_resources
 from operator import itemgetter
-import platform
-
 from pyramid_debugtoolbar.panels import DebugPanel
+from pyramid_debugtoolbar.compat import text_
 
 _ = lambda x: x
-
-plat = 'Python %s on %s' % (sys.version, platform.platform())
 
 packages = []
 for distribution in pkg_resources.working_set:
     name = distribution.project_name
-    packages.append({'version':distribution.version,
-                     'lowername':name.lower(),
-                     'name':name})
-    
-packages = sorted(packages, key=itemgetter('lowername'))
+    packages.append({'version': distribution.version,
+                     'lowername': name.lower(),
+                     'name': name})
 
+packages = sorted(packages, key=itemgetter('lowername'))
 pyramid_version = pkg_resources.get_distribution('pyramid').version
+
 
 class VersionDebugPanel(DebugPanel):
     """
@@ -37,10 +35,18 @@ class VersionDebugPanel(DebugPanel):
     def title(self):
         return _('Versions')
 
+    def _get_platform_name(self):
+        return platform.platform()
+
+    def get_platform(self):
+        return 'Python %s on %s' % (sys.version,
+                                    text_(self._get_platform_name(), 'utf8'))
+
+    @property
+    def properties(self):
+        return {'platform': self.get_platform(), 'packages': packages}
+
     def content(self):
-        vars = {'platform':plat, 'packages':packages}
         return self.render(
             'pyramid_debugtoolbar.panels:templates/versions.dbtmako',
-            vars, self.request)
-
-
+            self.properties, self.request)

--- a/pyramid_debugtoolbar/tests/test_panels.py
+++ b/pyramid_debugtoolbar/tests/test_panels.py
@@ -1,0 +1,26 @@
+"""Unittests for DebugPanels."""
+
+import unittest
+
+from pyramid_debugtoolbar.compat import PY3, text_type
+from pyramid import testing
+
+
+class TestVersionDebugPanel(unittest.TestCase):
+
+    def _make_one(self):
+        from pyramid_debugtoolbar.panels.versions import VersionDebugPanel
+        request = testing.DummyRequest()
+        return VersionDebugPanel(request)
+
+    def test_it_with_nonascii_platform_name(self):
+        panel = self._make_one()
+        test_string = b'Schr\xc3\xb6dinger\xe2\x80\x99s_Cat'
+        if PY3:
+            # it's unicode string in py3
+            test_string = test_string.decode('utf8')
+
+        panel._get_platform_name = lambda: test_string
+
+        platform = panel.properties['platform']
+        self.assertTrue(isinstance(platform, text_type))


### PR DESCRIPTION
Non-ascii characters in platform name, for example Fedora's <<Schrödinger’s Cat>>
causes VersionDebugPanel to fail with UnicodeDecodeError. Added compat.text_(.., 'utf8')
convertion and moved platform name discovery to helper method to be easily swaped in unit tests.
