### PR TITLE
Fix missing semicolon in toolbar.js

### DIFF
--- a/pyramid_debugtoolbar/static/js/toolbar.js
+++ b/pyramid_debugtoolbar/static/js/toolbar.js
@@ -176,7 +176,7 @@ pyramid_debugtoolbar_require([
         }
       },
       show_toolbar: function(animate, auto_hide) {
-        auto_hide = auto_hide || false
+        auto_hide = auto_hide || false;
         // Set up keybindings
         $(document).bind('keydown.pDebug', function(e) {
           if (e.keyCode == 27) {
@@ -213,6 +213,6 @@ pyramid_debugtoolbar_require([
       pdtb.init();
       $(".pDebugSortable").tablesorter();
     });
-  })
+  });
   $.noConflict(true);
 });


### PR DESCRIPTION
While changing toolbar.js for a separate WSGI app, I located missing semicolons.

Did not run selenium tests. Need to get firefox 21 or wait for Selenium RC to get fixed.
