### PR TITLE
Hexlify fix for python3

### DIFF
--- a/pyramid_debugtoolbar/toolbar.py
+++ b/pyramid_debugtoolbar/toolbar.py
@@ -1,4 +1,3 @@
-import binascii
 import sys
 import os
 
@@ -16,6 +15,7 @@ from pyramid_debugtoolbar.utils import logger
 from pyramid_debugtoolbar.utils import addr_in
 from pyramid_debugtoolbar.utils import last_proxy
 from pyramid_debugtoolbar.utils import debug_toolbar_url
+from pyramid_debugtoolbar.utils import hexlify
 from pyramid.httpexceptions import WSGIHTTPException
 from repoze.lru import LRUCache
 
@@ -106,7 +106,7 @@ def toolbar_tween_factory(handler, registry):
     auth_check = registry.queryUtility(IRequestAuthorization)
     exclude_prefixes = get_setting(settings, 'exclude_prefixes', [])
     registry.exc_history = exc_history = None
-    registry.pdtb_token = text_(binascii.hexlify(os.urandom(10)))
+    registry.pdtb_token = hexlify(os.urandom(10))
 
     if intercept_exc:
         registry.exc_history = exc_history = ExceptionHistory()
@@ -163,7 +163,7 @@ def toolbar_tween_factory(handler, registry):
                 response = request.invoke_subrequest(subrequest)
 
                 toolbar.process_response(request, response)
-                request.id = text_(binascii.hexlify(str(id(request))))
+                request.id = hexlify(id(request))
                 request_history.put(request.id, toolbar)
                 toolbar.inject(request, response)
                 return response
@@ -191,7 +191,7 @@ def toolbar_tween_factory(handler, registry):
                         response.status_int = 200
 
             toolbar.process_response(request, response)
-            request.id = text_(binascii.hexlify(str(id(request))))
+            request.id = hexlify(id(request))
             request_history.put(request.id, toolbar)
 
             if response.content_type in html_types:

--- a/pyramid_debugtoolbar/utils.py
+++ b/pyramid_debugtoolbar/utils.py
@@ -1,3 +1,4 @@
+import binascii
 import os.path
 import sys
 from logging import getLogger
@@ -6,9 +7,10 @@ from pyramid.util import DottedNameResolver
 from pyramid.settings import asbool
 
 from pyramid_debugtoolbar.compat import binary_type
-from pyramid_debugtoolbar.compat import text_type
+from pyramid_debugtoolbar.compat import bytes_
 from pyramid_debugtoolbar.compat import string_types
 from pyramid_debugtoolbar.compat import text_
+from pyramid_debugtoolbar.compat import text_type
 
 from pyramid_debugtoolbar import ipaddr
 
@@ -170,5 +172,14 @@ def last_proxy(addr):
 def find_request_history(request):
     return request.registry.parent_registry.request_history
 
+
 def debug_toolbar_url(request, *elements, **kw):
     return request.route_url('debugtoolbar', subpath=elements, **kw)
+
+
+def hexlify(value):
+    """Hexlify int, str then returns native str type."""
+    # If integer
+    str_ = str(value)
+    hexified = text_(binascii.hexlify(bytes_(str_)))
+    return hexified


### PR DESCRIPTION
Hi,

this pull req fixes tests for py32 and py33.

Hexlify is separated into utils.
