### PR TITLE
Escaped values before passed to mako.

### DIFF
--- a/pyramid_debugtoolbar/panels/templates/introspection.dbtmako
+++ b/pyramid_debugtoolbar/panels/templates/introspection.dbtmako
@@ -6,7 +6,7 @@
 	<table>
 	<thead>
 		<tr>
-			<th colspan="2"><a name="${intro.category_name}${intro.discriminator_hash}">${intro.type_name} ${intro.title}</a></th>
+			<th colspan="2"><a name="${intro.category_name}${str(intro.discriminator_hash)}">${intro.type_name} ${intro.title}</a></th>
 		</tr>
 	</thead>
 	<tbody>
@@ -43,7 +43,7 @@
 		% for i, ref in enumerate(entry['related']):
 		<tr class="${i%2 and 'pDebugEven' or 'pDebugOdd'}">
 			<td colspan="2">
-				<a href="#${ref.category_name}${ref.discriminator_hash}">${ref.type_name} ${ref.title}</a>
+				<a href="#${ref.category_name}${str(ref.discriminator_hash)}">${ref.type_name} ${ref.title}</a>
 			</td>
 		</tr>
 		% endfor

--- a/pyramid_debugtoolbar/panels/templates/performance.dbtmako
+++ b/pyramid_debugtoolbar/panels/templates/performance.dbtmako
@@ -41,10 +41,10 @@
         <tbody>
             % for i, row in enumerate(function_calls):
                 <tr class="${i%2 and 'pDebugEven' or 'pDebugOdd'}">
-                    <td>${row['ncalls']}</td>
-                    <td>${row['tottime']}</td>
+                    <td>${str(row['ncalls'])}</td>
+                    <td>${str(row['tottime'])}</td>
                     <td>${'%.4f' % row['percall']}</td>
-                    <td>${row['cumtime']}</td>
+                    <td>${str(row['cumtime'])}</td>
                     <td>${'%.4f' % row['percall_cum']}</td>
                     <td title="${row['filename_long']}">${row['filename']|h}</td>
                 </tr>

--- a/pyramid_debugtoolbar/panels/templates/routes.dbtmako
+++ b/pyramid_debugtoolbar/panels/templates/routes.dbtmako
@@ -12,7 +12,7 @@
 			<tr class="${i%2 and 'pDebugEven' or 'pDebugOdd'}">
 				<td>${route_info['route'].name|h}</td>
 				<td>${route_info['route'].pattern|h}</td>
-				<td>${route_info['view_callable']}</td>
+				<td>${repr(route_info['view_callable'])}</td>
 				<td>${route_info['predicates']}</td>
 			</tr>
 		% endfor

--- a/pyramid_debugtoolbar/panels/templates/tweens.dbtmako
+++ b/pyramid_debugtoolbar/panels/templates/tweens.dbtmako
@@ -9,7 +9,7 @@
 	<tbody>
 		% for i, (name, tween) in enumerate(tweens):
 			<tr class="${i%2 and 'pDebugEven' or 'pDebugOdd'}">
-				<td>${i}</td>
+				<td>${str(i)}</td>
 				<td>${name}</td>
 			</tr>
 		% endfor


### PR DESCRIPTION
Because he MarkupSafe 0.17 is not py3.2 compatible. And the template engine breaks because repr() and str() are not called.

We need to think about how to test that kind of stuff to. Any suggestions?
