### PR TITLE
Added support for python2 objects with unicode __repr__()

### DIFF
--- a/pyramid_debugtoolbar/panels/renderings.py
+++ b/pyramid_debugtoolbar/panels/renderings.py
@@ -29,7 +29,9 @@ class RenderingsDebugPanel(DebugPanel):
         except:
             # crazyass code raises an exception during __repr__ (formish)
             val = '<unknown>'
-        self.renderings.append(dict(name=name, system=dictrepr(event), val=text_(val, 'utf-8')))
+        self.renderings.append(
+            dict(name=name, system=dictrepr(event), val=text_(val, 'utf-8'))
+            )
 
     def nav_title(self):
         return _('Renderers')


### PR DESCRIPTION
See issue #70

When an object in Python 2 is passed to a template and has unicode characters in its `__repr__()` output

ex:

```
class foo(object):
    def __repr__(self):
        return u'あ'.encode('utf-8')
```

a UnicodeDecodeError is thrown.

This patch (mostly taken from Benwah in the comments of #70), converts the renderings in the toolbar to utf-8 unicode.  I have observed this has fixed the issue and works for unicode characters encoded as unicode, ascii characters encoded as unicode, and ascii characters not encoded.

This patch is ignored in Python 3, as unicode is used by default.
