### PR TITLE
Fix live-update of request history in python 2.6

### DIFF
--- a/pyramid_debugtoolbar/views.py
+++ b/pyramid_debugtoolbar/views.py
@@ -243,7 +243,7 @@ def request_view(request):
             'request_id': request_id
             }
 
-U_SSE_PAYLOAD = text_("id:{}\nevent: new_request\ndata:{}\n\n")
+U_SSE_PAYLOAD = text_("id:{0}\nevent: new_request\ndata:{1}\n\n")
 @view_config(route_name='debugtoolbar.sse',
              permission=NO_PERMISSION_REQUIRED)
 def sse(request):


### PR DESCRIPTION
Python 2.6 does not allow empty field names in format strings.

This causes the sse view to throw a `ValueError: zero length field name in format` exception, which breaks the live-updating of the request history in the left sidebar.
