### PR TITLE
SQL result table overflows panel

### DIFF
--- a/pyramid_debugtoolbar/panels/templates/sqlalchemy_select.dbtmako
+++ b/pyramid_debugtoolbar/panels/templates/sqlalchemy_select.dbtmako
@@ -16,6 +16,7 @@
 			<dd>${'%.2f' % (duration)} ms</dd>
 		</dl>
 		% if result:
+                <h4>Results</h4>
 		<table class="djSqlExplain table table-striped"
 >
 			<thead>


### PR DESCRIPTION
The results for a SQL query are presented in a table with one column per parameter. This can easily overflow the panel.
![image](https://cloud.githubusercontent.com/assets/199657/3063918/2efe1bb0-e249-11e3-8cd0-551827392dbb.png)
