### PR TITLE
Fix to handle XHTML

### DIFF
--- a/pyramid_debugtoolbar/toolbar.py
+++ b/pyramid_debugtoolbar/toolbar.py
@@ -263,7 +263,7 @@ toolbar_html_template = """\
 <div id="pDebug">
     <div style="display: block; %(button_style)s" id="pDebugToolbarHandle">
         <a title="Show Toolbar" id="pShowToolBarButton"
-           href="%(toolbar_url)s" target="pDebugToolbar">&laquo; FIXME: Debug Toolbar</a>
+           href="%(toolbar_url)s" target="pDebugToolbar">&#171; FIXME: Debug Toolbar</a>
     </div>
 </div>
 """


### PR DESCRIPTION
I suppose that 'application/xml+html' would be a typo of 'application/xhtml+xml'.
This fixes that the toolbar doesn't show up on XHTML pages.

Thanks.
