### PR TITLE
Use root_path in sse URL

### DIFF
--- a/pyramid_debugtoolbar/templates/toolbar.dbtmako
+++ b/pyramid_debugtoolbar/templates/toolbar.dbtmako
@@ -83,7 +83,7 @@
                 var request_id = item[0];
                 var active = item[2];
 
-                html += '<li class="'+active+'"><a href="/_debug_toolbar/'+request_id+'" title="'+details.path+'">';
+                html += '<li class="'+active+'"><a href="${root_path}'+request_id+'" title="'+details.path+'">';
                 html += '<span class="badge pull-right _'+details.status_code+'">'+details.status_code+'</span>';
                 html += details.method+'<br>'+details.path;
                 html += '</a></li>';
@@ -101,7 +101,7 @@
                 source.close();
             }
 
-            source = new EventSource('/_debug_toolbar/sse?request_id=${request_id}');
+            source = new EventSource('${root_path}sse?request_id=${request_id}');
             source.addEventListener('new_request', new_request);
         }
 


### PR DESCRIPTION
Previously, when an app was mounted at anything other than '/', the SSE functionality of the debug toolbar was failing as it was assuming it could hit /debug_toolbar/sse. This PR adds a change so that the template uses the 'root_path' variable to determine the sse url. This root_path was already being passed in, just not used.
