### PR TITLE
changed the link in header logo, so it always hits the debugtoolbar

### DIFF
--- a/pyramid_debugtoolbar/templates/toolbar.dbtmako
+++ b/pyramid_debugtoolbar/templates/toolbar.dbtmako
@@ -31,7 +31,7 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </button>
-          <a class="navbar-brand" href="/_debug_toolbar/">
+          <a class="navbar-brand" href="${root_path}">
             <!-- <img src="${static_path}img/pyramid.png"/> -->
             Pyramid DebugToolbar</a>
         </div>


### PR DESCRIPTION
This is a small change I wanted to suggest.

I often do long interactive debugging sessions with some ajax requests, with the debugger in a separate tab.

Hitting "reload" or clicking the logo will not reload after a restart/reload -- because the debugger's url is "/_debug_toolbar/{{ID}}" and {{ID}} no longer exists.  

The simple solution is to jut have the logo link to the `/_debug_toolbar/` url itself and force a full load.
