### PR TITLE
fixed issue_146 by incorporating the bootstrap reset

### DIFF
--- a/pyramid_debugtoolbar/panels/templates/sqlalchemy.dbtmako
+++ b/pyramid_debugtoolbar/panels/templates/sqlalchemy.dbtmako
@@ -48,3 +48,17 @@
 </div>
 
 <!-- /.modal -->
+
+##
+## See 	"Twitter bootstrap remote modal shows same content everytime"
+## 		http://stackoverflow.com/questions/12286332/twitter-bootstrap-remote-modal-shows-same-content-everytime
+<script src="${static_path}js/jquery-1.10.2.min.js"></script>
+<script src="${static_path}js/bootstrap.min.js"></script>
+<script type="text/javascript">
+$("#ExplainModal").on("hidden.bs.modal", function (e) {
+    $(e.target).removeData("bs.modal").find(".modal-content").empty();
+});
+$("#SelectModal").on("hidden.bs.modal", function (e) {
+    $(e.target).removeData("bs.modal").find(".modal-content").empty();
+});
+</script>


### PR DESCRIPTION
This was killing me. 

After a bit of searching, issue https://github.com/Pylons/pyramid_debugtoolbar/issues/146 is caused by the implementation of bootstrap's modal.

the fix is to reset the content when it is hidden.

In order to make this panel work, it needs to load both the jquery and bootstrap JS.  i didn't know the best place to put it -- perhaps there is a better file.  however it needs to be loaded onto the current template (not just toolbar.dbtmako)
