### PR TITLE
Fix display of repeated POST vars

### DIFF
--- a/pyramid_debugtoolbar/panels/request_vars.py
+++ b/pyramid_debugtoolbar/panels/request_vars.py
@@ -26,8 +26,7 @@ class RequestVarsDebugPanel(DebugPanel):
             attr_dict['response'] = repr(attr_dict['response'])
         data.update({
             'get': [(k, request.GET.getall(k)) for k in request.GET],
-            'post': [(k, [saferepr(p) for p in request.POST.getall(k)])
-                    for k in request.POST],
+            'post': [(k, saferepr(v)) for k, v in request.POST.items()],
             'cookies': [(k, request.cookies.get(k)) for k in request.cookies],
             'attrs': dictrepr(attr_dict),
             'environ': dictrepr(request.environ),

--- a/pyramid_debugtoolbar/panels/templates/request_vars.dbtmako
+++ b/pyramid_debugtoolbar/panels/templates/request_vars.dbtmako
@@ -85,7 +85,7 @@
 		% for i, (key, value) in enumerate(post):
 		<tr class="${i%2 and 'pDebugEven' or 'pDebugOdd'}">
 			<td>${key|h}</td>
-			<td>${', '.join(value)|h}</td>
+			<td>${value|h}</td>
 		</tr>
 		% endfor
 	</tbody>


### PR DESCRIPTION
The keys for POST vars with duplicate names were being (correctly) listed in their orignal order, however *all* values for each of these keys were (incorrectly) listed for each occurance of the duplicated keys.

This is particularly confusing, e.g., when looking at, e.g. [peppercorn](http://peppercorn.readthedocs.org/)-encoded data. By way of example, currently peppercorn data consisting of two simple mappings is currently (incorrectly) displayed as:

Variable | Value
---------- | ----------
\__start\__	| u'A:mapping', u'B:mapping'
score	| u'1', u'2'
\__end\__	| u'A:mapping', u'B:mapping'
\__start\__	| u'A:mapping', u'B:mapping'
score	| u'1', u'2'
\__end\__	| u'A:mapping', u'B:mapping'

With this patch, the same data is correctly displayed as:

Variable | Value
---------- | ----------
\__start\__	| u'A:mapping'
score	| u'1'
\__end\__	| u'A:mapping'
\__start\__	|  u'B:mapping'
score	| u'2'
\__end\__	|  u'B:mapping'