### PR TITLE
request panel improvements, removed old css

### DIFF
--- a/pyramid_debugtoolbar/panels/request_vars.py
+++ b/pyramid_debugtoolbar/panels/request_vars.py
@@ -30,6 +30,7 @@ class RequestVarsDebugPanel(DebugPanel):
             'cookies': [(k, request.cookies.get(k)) for k in request.cookies],
             'attrs': dictrepr(attr_dict),
             'environ': dictrepr(request.environ),
+            'original_request': request,
         })
         if hasattr(request, 'session'):
             data.update({

--- a/pyramid_debugtoolbar/panels/templates/headers.dbtmako
+++ b/pyramid_debugtoolbar/panels/templates/headers.dbtmako
@@ -8,7 +8,7 @@
 	</thead>
 	<tbody>
 		% for i, (key, value) in enumerate(request_headers):
-			<tr class="${i%2 and 'pDebugEven' or 'pDebugOdd'}">
+			<tr>
 				<td>${key|h}</td>
 				<td>${value|h}</td>
 			</tr>
@@ -26,7 +26,7 @@
 	</thead>
 	<tbody>
 		% for i, (key, value) in enumerate(response_headers):
-			<tr class="${i%2 and 'pDebugEven' or 'pDebugOdd'}">
+			<tr>
 				<td>${key|h}</td>
 				<td>${value|h}</td>
 			</tr>

--- a/pyramid_debugtoolbar/panels/templates/introspection.dbtmako
+++ b/pyramid_debugtoolbar/panels/templates/introspection.dbtmako
@@ -13,7 +13,7 @@
 		<% i = 0 %>
 		% for k, v in sorted(intro.items()):
 		% if v:
-		<tr class="${i%2 and 'pDebugEven' or 'pDebugOdd'}">
+		<tr>
 			<td>${k}</td>
 			<td>${debug_repr(v)|n}</td>
 		</tr>
@@ -41,7 +41,7 @@
 	</thead>
 	<tbody>
 		% for i, ref in enumerate(entry['related']):
-		<tr class="${i%2 and 'pDebugEven' or 'pDebugOdd'}">
+		<tr>
 			<td colspan="2">
 				<a href="#${ref.category_name}${str(ref.discriminator_hash)}">${ref.type_name} ${ref.title}</a>
 			</td>

--- a/pyramid_debugtoolbar/panels/templates/logger.dbtmako
+++ b/pyramid_debugtoolbar/panels/templates/logger.dbtmako
@@ -10,7 +10,7 @@
 		</thead>
 		<tbody>
 			% for i, record in enumerate(records):
-				<tr class="${i%2 and 'pDebugEven' or 'pDebugOdd'}">
+				<tr>
 					<td>${record['level']}</td>
 					<td>${record['time']}</td>
 					<td>${record['message']}</td>

--- a/pyramid_debugtoolbar/panels/templates/performance.dbtmako
+++ b/pyramid_debugtoolbar/panels/templates/performance.dbtmako
@@ -12,7 +12,7 @@
 	</thead>
 	<tbody>
 		% for i, (key, value) in enumerate(timing_rows):
-			<tr class="${i%2 and 'pDebugEven' or 'pDebugOdd'}">
+			<tr>
 				<td>${key|h}</td>
 				<td>${value|h}</td>
 			</tr>
@@ -40,7 +40,7 @@
         </thead>
         <tbody>
             % for i, row in enumerate(function_calls):
-                <tr class="${i%2 and 'pDebugEven' or 'pDebugOdd'}">
+                <tr>
                     <td>${str(row['ncalls'])}</td>
                     <td>${str(row['tottime'])}</td>
                     <td>${'%.4f' % row['percall']}</td>

--- a/pyramid_debugtoolbar/panels/templates/renderings.dbtmako
+++ b/pyramid_debugtoolbar/panels/templates/renderings.dbtmako
@@ -16,7 +16,7 @@
 			<th colspan="2">Rendering Value</th>
 		</tr>
 	</thead>
-	<tbody>	
+	<tbody>
 		<tr class="pDebugOdd">
 			<td colspan="2">${rendering['val']|h}</td>
 		</tr>
@@ -26,9 +26,9 @@
 			<th colspan="2">System Values</th>
 		</tr>
 	</thead>
-	<tbody>	
+	<tbody>
 		% for i, (key, value) in enumerate(rendering['system']):
-		<tr class="${i%2 and 'pDebugEven' or 'pDebugOdd'}">
+		<tr>
 			<td>${key|h}</td>
 			<td>${value|h}</td>
 		</tr>

--- a/pyramid_debugtoolbar/panels/templates/request_vars.dbtmako
+++ b/pyramid_debugtoolbar/panels/templates/request_vars.dbtmako
@@ -1,24 +1,87 @@
+<h4>Pyramid Request Properties</h4>
+<%
+    # format is
+    # ( attr_, is_show_dict, is_execute_method )
+    attrs_ = (
+        ('application_url', None, None),
+        ('authenticated_userid', None, None),
+        ('authorization', None, None),
+        ('cache_control', None, None),
+        ('context', None, None),
+        ('current_route_path', None, True),
+        ('current_route_url', None, True),
+        ('effective_principals', None, None),
+        ('exc_info', None, None),
+        ('exception', None, None),
+        ('locale_name', None, None),
+        ('matchdict', None, None),
+        ('matched_route', True, None),
+        # ('registry', None, None),  # as a 'string' will be the python package name; as a dict will be the contents
+        ('root', None, None),
+        ('subpath', None, None),
+        ('traversed', None, None),
+        ('unauthenticated_userid', None, None),
+        ('view_name', None, None),
+        ('virtual_root_path', None, None),
+        ('virtual_root', None, None),
+    )
+%>
+<table class="table table-striped table-condensed">
+% for (attr_, is_show_dict, is_execute_method) in sorted(attrs_):
+    <%
+        # earlier versions of pyramid may not have newer attrs (ie, authenticated_userid)
+        if not hasattr(original_request, attr_):
+            continue
+        value = None
+        if is_show_dict:
+            value = getattr(original_request, attr_).__dict__
+        elif is_execute_method:
+            value = getattr(original_request, attr_)()
+        else:
+            value = getattr(original_request, attr_)
+    %>
+    <tr>
+        <th>${attr_}</th>
+        <td>
+        	% if isinstance(value, dict):
+	            <table class="table table-striped table-condensed">
+	            	% for k in sorted(value.keys()):
+	            		<tr>
+	            			<th>${k}</th>
+	            			<td>${value[k]}</td>
+	            	% endfor
+	            </table>
+	        % else :
+	            ${value}
+	        % endif
+        </td>
+    </tr>
+% endfor
+</table>
+
+
+
 <h4>Cookie Variables</h4>
 % if cookies:
-<table class="table table-striped">
-	<colgroup>
-		<col style="width:20%"/>
-		<col/>
-	</colgroup>
-	<thead>
-		<tr>
-			<th>Variable</th>
-			<th>Value</th>
-		</tr>
-	</thead>
-	<tbody>
-		% for i, (key, value) in enumerate(cookies):
-		<tr class="${i%2 and 'pDebugEven' or 'pDebugOdd'}">
-			<td>${key|h}</td>
-			<td>${value|h}</td>
-		</tr>
-		% endfor
-	</tbody>
+<table class="table table-striped table-condensed">
+    <colgroup>
+        <col style="width:20%"/>
+        <col/>
+    </colgroup>
+    <thead>
+        <tr>
+            <th>Variable</th>
+            <th>Value</th>
+        </tr>
+    </thead>
+    <tbody>
+        % for i, (key, value) in enumerate(sorted(cookies)):
+        <tr>
+            <td>${key|h}</td>
+            <td>${value|h}</td>
+        </tr>
+        % endfor
+    </tbody>
 </table>
 % else:
 <p>No cookie data</p>
@@ -26,25 +89,25 @@
 
 <h4>Session Variables</h4>
 % if session:
-<table class="table table-striped">
-	<colgroup>
-		<col style="width:20%"/>
-		<col/>
-	</colgroup>
-	<thead>
-		<tr>
-			<th>Variable</th>
-			<th>Value</th>
-		</tr>
-	</thead>
-	<tbody>
-		% for i, (key, value) in enumerate(session):
-		<tr class="${i%2 and 'pDebugEven' or 'pDebugOdd'}">
-			<td>${key|h}</td>
-			<td>${value|h}</td>
-		</tr>
-		% endfor
-	</tbody>
+<table class="table table-striped table-condensed">
+    <colgroup>
+        <col style="width:20%"/>
+        <col/>
+    </colgroup>
+    <thead>
+        <tr>
+            <th>Variable</th>
+            <th>Value</th>
+        </tr>
+    </thead>
+    <tbody>
+        % for i, (key, value) in enumerate(sorted(session)):
+        <tr>
+            <td>${key|h}</td>
+            <td>${value|h}</td>
+        </tr>
+        % endfor
+    </tbody>
 </table>
 % else:
 <p>No session data</p>
@@ -52,21 +115,21 @@
 
 <h4>GET Variables</h4>
 % if get:
-<table class="table table-striped">
-	<thead>
-		<tr>
-			<th>Variable</th>
-			<th>Value</th>
-		</tr>
-	</thead>
-	<tbody>
-		% for i, (key, value) in enumerate(get):
-		<tr class="${i%2 and 'pDebugEven' or 'pDebugOdd'}">
-			<td>${key|h}</td>
-			<td>${', '.join(value)|h}</td>
-		</tr>
-		% endfor
-	</tbody>
+<table class="table table-striped table-condensed">
+    <thead>
+        <tr>
+            <th>Variable</th>
+            <th>Value</th>
+        </tr>
+    </thead>
+    <tbody>
+        % for i, (key, value) in enumerate(sorted(get)):
+        <tr>
+            <td>${key|h}</td>
+            <td>${', '.join(value)|h}</td>
+        </tr>
+        % endfor
+    </tbody>
 </table>
 % else:
 <p>No GET data</p>
@@ -74,21 +137,21 @@
 
 <h4>POST Variables</h4>
 % if post:
-<table class="table table-striped">
-	<thead>
-		<tr>
-			<th>Variable</th>
-			<th>Value</th>
-		</tr>
-	</thead>
-	<tbody>
-		% for i, (key, value) in enumerate(post):
-		<tr class="${i%2 and 'pDebugEven' or 'pDebugOdd'}">
-			<td>${key|h}</td>
-			<td>${value|h}</td>
-		</tr>
-		% endfor
-	</tbody>
+<table class="table table-striped table-condensed">
+    <thead>
+        <tr>
+            <th>Variable</th>
+            <th>Value</th>
+        </tr>
+    </thead>
+    <tbody>
+        % for i, (key, value) in enumerate(sorted(post)):
+        <tr>
+            <td>${key|h}</td>
+            <td>${value|h}</td>
+        </tr>
+        % endfor
+    </tbody>
 </table>
 % else:
 <p>No POST data</p>
@@ -96,21 +159,21 @@
 
 <h4>Request attributes</h4>
 % if attrs:
-<table class="table table-striped">
-	<thead>
-		<tr>
-			<th>Attribute</th>
-			<th>Value</th>
-		</tr>
-	</thead>
-	<tbody>
-		% for i, (key, value) in enumerate(attrs):
-		<tr class="${i%2 and 'pDebugEven' or 'pDebugOdd'}">
-			<td>${key|h}</td>
-			<td>${value|h}</td>
-		</tr>
-		% endfor
-	</tbody>
+<table class="table table-striped table-condensed">
+    <thead>
+        <tr>
+            <th>Attribute</th>
+            <th>Value</th>
+        </tr>
+    </thead>
+    <tbody>
+        % for i, (key, value) in enumerate(sorted(attrs)):
+        <tr>
+            <td>${key|h}</td>
+            <td>${value|h}</td>
+        </tr>
+        % endfor
+    </tbody>
 </table>
 % else:
 <p>No request attributes</p>
@@ -118,22 +181,24 @@
 
 <h4>Request environ</h4>
 % if environ:
-<table class="table table-striped">
-	<thead>
-		<tr>
-			<th>Attribute</th>
-			<th>Value</th>
-		</tr>
-	</thead>
-	<tbody>
-		% for i, (key, value) in enumerate(environ):
-		<tr class="${i%2 and 'pDebugEven' or 'pDebugOdd'}">
-			<td>${key|h}</td>
-			<td>${value|h}</td>
-		</tr>
-		% endfor
-	</tbody>
+<table class="table table-striped table-condensed">
+    <thead>
+        <tr>
+            <th>Attribute</th>
+            <th>Value</th>
+        </tr>
+    </thead>
+    <tbody>
+        % for i, (key, value) in enumerate(sorted(environ)):
+        <tr>
+            <td>${key|h}</td>
+            <td>${value|h}</td>
+        </tr>
+        % endfor
+    </tbody>
 </table>
 % else:
 <p>No request environ</p>
 % endif
+
+<hr/><hr/><hr/>

--- a/pyramid_debugtoolbar/panels/templates/routes.dbtmako
+++ b/pyramid_debugtoolbar/panels/templates/routes.dbtmako
@@ -9,7 +9,7 @@
 	</thead>
 	<tbody>
 		% for i, route_info in enumerate(routes):
-			<tr class="${i%2 and 'pDebugEven' or 'pDebugOdd'}">
+			<tr>
 				<td>${route_info['route'].name|h}</td>
 				<td>${route_info['route'].pattern|h}</td>
 				<td>${repr(route_info['view_callable'])}</td>

--- a/pyramid_debugtoolbar/panels/templates/settings.dbtmako
+++ b/pyramid_debugtoolbar/panels/templates/settings.dbtmako
@@ -7,7 +7,7 @@
 	</thead>
 	<tbody>
 		% for i, (key, value) in enumerate(settings):
-			<tr class="${i%2 and 'pDebugEven' or 'pDebugOdd'}">
+			<tr>
 				<td>${key|h}</td>
 				<td>${value|h}</td>
 			</tr>

--- a/pyramid_debugtoolbar/panels/templates/sqlalchemy.dbtmako
+++ b/pyramid_debugtoolbar/panels/templates/sqlalchemy.dbtmako
@@ -10,7 +10,7 @@
 	</thead>
 	<tbody>
 	% for i, query in enumerate(queries):
-		<tr class="${i%2 and 'pDebugEven' or 'pDebugOdd'}">
+		<tr>
 			<td>${'%.2f' % query['duration']}</td>
 			<td>
 

--- a/pyramid_debugtoolbar/panels/templates/sqlalchemy_explain.dbtmako
+++ b/pyramid_debugtoolbar/panels/templates/sqlalchemy_explain.dbtmako
@@ -26,7 +26,7 @@
 			</thead>
 			<tbody>
 				% for i, row in enumerate(result):
-				    <tr class="${i%2 and 'pDebugEven' or 'pDebugOdd'}">
+				    <tr>
 						% for column in row:
 						<td>${str(column).replace(' ', '&nbsp;')|n}</td>
 						% endfor

--- a/pyramid_debugtoolbar/panels/templates/sqlalchemy_select.dbtmako
+++ b/pyramid_debugtoolbar/panels/templates/sqlalchemy_select.dbtmako
@@ -27,7 +27,7 @@
 			</thead>
 			<tbody>
 				% for i, row in enumerate(result):
-				    <tr class="${i%2 and 'pDebugEven' or 'pDebugOdd'}">
+				    <tr>
 						% for column in row:
 						<td>${column}</td>
 						% endfor

--- a/pyramid_debugtoolbar/panels/templates/tweens.dbtmako
+++ b/pyramid_debugtoolbar/panels/templates/tweens.dbtmako
@@ -8,7 +8,7 @@
 	</thead>
 	<tbody>
 		% for i, (name, tween) in enumerate(tweens):
-			<tr class="${i%2 and 'pDebugEven' or 'pDebugOdd'}">
+			<tr>
 				<td>${str(i)}</td>
 				<td>${name}</td>
 			</tr>

--- a/pyramid_debugtoolbar/panels/templates/versions.dbtmako
+++ b/pyramid_debugtoolbar/panels/templates/versions.dbtmako
@@ -12,7 +12,7 @@
 	</thead>
 	<tbody>
 		% for i, package in enumerate(packages):
-			<tr class="${i%2 and 'pDebugEven' or 'pDebugOdd'}">
+			<tr>
 				<td>${package['name']|h}</td>
 				<td>${package['version']|h}</td>
 			</tr>


### PR DESCRIPTION
* added support for more request properties to RequestVars panel [https://github.com/Pylons/pyramid_debugtoolbar/issues/209]

* removed old css classes that were not necessary [https://github.com/Pylons/pyramid_debugtoolbar/issues/214]

The request panel tables were also given a `table-condensed` css class, which just reduces the padding.

    - <table class="table table-striped">
    + <table class="table table-striped table-condensed">

The various panel loops were also given a call to `sorted`, so the keys are now in somewhat alphabetical order (they aren't sorted on "lower(key)", so they sort A-Z then a-z).