### PR TITLE
Adds Pyramid version tests; bumps required version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ env:
   - TOXENV=py2-docs
   - TOXENV=py3-docs
   - TOXENV=py2-cover,py3-cover,coverage
+  - TOXENV=py27-pyramid14
+  - TOXENV=py27-pyramid15
 
 install:
   - travis_retry pip install tox

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -33,6 +33,13 @@ unreleased
   executing queries with parameters that are not serializable.
   See https://github.com/Pylons/pyramid_debugtoolbar/pull/227
 
+- Adds Pyramid version tests and bumps required Pyramid version to 1.4.
+  The pyramid_mako dependency requires 1.3, but debugtoolbar also uses
+  invoke_subrequest which was added in 1.4. The invoke_subrequest call was added
+  in pyramid_debugtoolbar 2.0; if you need Pyramid 1.3 compatibility, try an older
+  version. See https://github.com/Pylons/pyramid_debugtoolbar/issues/183
+  and https://github.com/Pylons/pyramid_debugtoolbar/pull/225
+
 2.3 (2015-01-05)
 ----------------
 

--- a/pyramid_debugtoolbar/__init__.py
+++ b/pyramid_debugtoolbar/__init__.py
@@ -107,11 +107,11 @@ def transform_settings(settings):
 
     return parsed
 
-def set_request_authorization_callback(request, callback):
+def set_request_authorization_callback(config, callback):
     """
     Register IRequestAuthorization utility to authorize toolbar per request.
     """
-    request.registry.registerUtility(callback, IRequestAuthorization)
+    config.registry.registerUtility(callback, IRequestAuthorization)
 
 def includeme(config):
     """ Activate the debug toolbar; usually called via

--- a/pyramid_debugtoolbar/toolbar.py
+++ b/pyramid_debugtoolbar/toolbar.py
@@ -217,12 +217,15 @@ def toolbar_tween_factory(handler, registry, _logger=None):
                     subrequest.path_info[len(request.script_name):]
                 response = request.invoke_subrequest(subrequest)
 
+                # The original request must be processed so that the panel data exists
+                # if the request is later examined in the full toolbar view.
                 toolbar.process_response(request, response)
 
                 toolbar.response = response
                 toolbar.status_int = response.status_int
 
                 request_history.put(request.pdtb_id, toolbar)
+                # Inject the button to activate the full toolbar view.
                 toolbar.inject(request, response)
                 return response
             else:

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ except IOError:
     README = CHANGES = ''
 
 install_requires = [
-    'pyramid>=1.2dev',
+    'pyramid>=1.4',
     'pyramid_mako>=0.3.1', # lazy configuration loading works
     'repoze.lru',
     ]

--- a/tests/test_toolbar.py
+++ b/tests/test_toolbar.py
@@ -252,7 +252,7 @@ class Test_toolbar_handler(unittest.TestCase):
         response = self._callFUT(request, handler, _logger=logger)
         self.assertEqual(len(request.exc_history.tracebacks), 1)
         self.assertFalse(hasattr(request, 'debug_toolbar'))
-        self.assertTrue(response.status_int, 500)
+        self.assertEqual(response.status_int, 500)
 
     def test_it_intercept_redirect_nonredirect_code(self):
         request = Request.blank('/')
@@ -287,7 +287,7 @@ class Test_toolbar_handler(unittest.TestCase):
         request.remote_addr = '127.0.0.1'
         logger = DummyLogger()
         response = self._callFUT(request, handler, _logger=logger)
-        self.assertTrue(response.status_int, 500)
+        self.assertEqual(response.status_int, 500)
         self.assertTrue(
             b'NotImplementedError: K\xc3\xa4se!\xe2\x98\xa0' in response.body or
             # Python 3: the byte exception is escaped
@@ -307,7 +307,7 @@ class Test_toolbar_handler(unittest.TestCase):
         logger = DummyLogger()
         response = self._callFUT(request, handler, _logger=logger)
         self.assertFalse(hasattr(request, 'debug_toolbar'))
-        self.assertTrue(response.status_int, 500)
+        self.assertEqual(response.status_int, 500)
 
     def test_show_on_exc_without_exc_raised(self):
         request = Request.blank('/')
@@ -322,7 +322,7 @@ class Test_toolbar_handler(unittest.TestCase):
         request.registry = self.config.registry
         request.remote_addr = '127.0.0.1'
         response = self._callFUT(request, handler)
-        self.assertTrue(response.status_int, 200)
+        self.assertEqual(response.status_int, 200)
         self.assertEqual(response.body, b"<html><body>OK!</body></html>")
         self.assertFalse(hasattr(request, 'debug_toolbar'))
 
@@ -339,7 +339,7 @@ class Test_toolbar_handler(unittest.TestCase):
         request.registry = self.config.registry
         request.remote_addr = '127.0.0.1'
         response = self._callFUT(request, handler)
-        self.assertTrue(response.status_int, 200)
+        self.assertEqual(response.status_int, 200)
         self.assertNotEqual(response.body, b"<html><body>OK!</body></html>")
         self.assertFalse(hasattr(request, 'debug_toolbar'))
 

--- a/tests/test_toolbar.py
+++ b/tests/test_toolbar.py
@@ -55,7 +55,7 @@ class DebugToolbarTests(unittest.TestCase):
         response = Response('<body></body>')
         response.content_type = 'text/html'
         request = Request.blank('/')
-        request.pdbt_id = 'abc'
+        request.pdtb_id = 'abc'
         request.registry = self.config.registry
         toolbar = self._makeOne(request, [DummyPanel], [DummyPanel], [])
         toolbar.inject(request, response)
@@ -71,7 +71,7 @@ class DebugToolbarTests(unittest.TestCase):
         response = Response('<body></body>')
         response.content_type = 'text/html'
         request = Request.blank('/')
-        request.pdbt_id = 'abc'
+        request.pdtb_id = 'abc'
         request.registry = self.config.registry
         toolbar = self._makeOne(request, [DummyPanel], [DummyPanel], [])
         toolbar.inject(request, response)

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist =
     py26,py27,py32,py33,py34,pypy,pypy3,
+    py27-pyramid{14,15},
     {py2,py3}-docs,
     {py2,py3}-cover,coverage
 
@@ -17,6 +18,10 @@ basepython =
     pypy3: pypy3
     py2: python2.7
     py3: python3.4
+
+deps =
+    pyramid14: pyramid <= 1.4.99
+    pyramid15: pyramid <= 1.5.99
 
 commands =
     pip install pyramid_debugtoolbar[testing]


### PR DESCRIPTION
pyramid_debugtoolbar doesn't run under Pyramid 1.2.x anymore because the latest pyramid_mako requires an API introduced in 1.3

closes #224.