### PR TITLE
Allow the auth predicate to protect toolbar views.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -22,6 +22,9 @@ unreleased
 - Fix display of POST variables where the same key is used multiple times.
   See https://github.com/Pylons/pyramid_debugtoolbar/pull/210
 
+- Fix auth callback so it protects the toolbar views. Auth system is tested now.
+  See https://github.com/Pylons/pyramid_debugtoolbar/pull/226
+
 2.3 (2015-01-05)
 ----------------
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -116,3 +116,4 @@ Contributors
 - Bert JW Regeer, 2014-04-25
 - Jonathan Vanasco, 2014-04-30
 - Marco Martinez, 2014-12-26
+- Jon Rosebaugh, 2015-05-21

--- a/pyramid_debugtoolbar/views.py
+++ b/pyramid_debugtoolbar/views.py
@@ -35,7 +35,7 @@ def valid_host(info, request):
 
 
 def valid_request(info, request):
-    auth_check = request.registry.queryUtility(IRequestAuthorization)
+    auth_check = request.registry.parent_registry.queryUtility(IRequestAuthorization)
     return auth_check(request) if auth_check else True
 
 

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ else:
     install_requires.append('Pygments')
 
 testing_extras = [
+    'WebTest',
     'nose',
     'coverage',
     ]

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,78 @@
+import unittest
+import webtest
+from pyramid import testing
+
+from pyramid.config import Configurator
+from pyramid.response import Response
+
+HTML = """
+<html>
+<head><title>Hello from Pyramid</title></head>
+<body>Hello %(name)s!</body>
+</html>
+"""
+
+
+def app_view(request):
+    return Response(
+        HTML % request.matchdict,
+        content_type='text/html',
+    )
+
+
+def auth_check(request):
+    return request.remote_user == 'admin'
+
+
+def make_app():
+    config = Configurator()
+    config.include('pyramid_debugtoolbar')
+    config.set_debugtoolbar_request_authorization(auth_check)
+    config.add_route('hello', '/hello/{name}')
+    config.add_view(app_view, route_name='hello')
+    app = config.make_wsgi_app()
+    return app
+
+
+class Test_auth(unittest.TestCase):
+    def setUp(self):
+        self.config = testing.setUp()
+        self.testapp = webtest.TestApp(make_app())
+
+    def _req(self, url, remote_user=None, **kw):
+        environ = {'REMOTE_ADDR': '127.0.0.1'}
+        if remote_user:
+            environ['REMOTE_USER'] = remote_user
+        resp = self.testapp.get(url, extra_environ=environ, **kw)
+        return resp
+
+    def test_unauthenticated(self):
+        resp = self._req('/hello/pyramid')
+        self.assertEqual(resp.content_type, 'text/html')
+        self.assertEqual(resp.html.body.string, 'Hello pyramid!')
+        # Python 2.6 doesn't include assertIsNone or other useful asserts. Sigh.
+        self.assertTrue(resp.html.body.script is None, 'not None')
+        self.assertTrue(resp.html.body.div is None, 'not None')
+
+    def test_authenticated_toolbar_injection(self):
+        resp = self._req('/hello/secrets', remote_user='admin')
+        self.assertTrue(resp.html.body.script is not None, 'unexpectedly None')
+        # dive into the request history stored by the toolbar tween
+        request_id = self.testapp.app.registry.request_history[0][0]
+        # check it against the link in the injected html
+        self.assertTrue(request_id in resp.html.body.div.div.a['href'], 'request_id not found in html')
+
+    def test_authenticated_toolbar_views(self):
+        resp = self._req('/hello/rumors', remote_user='admin')
+        new_url = resp.html.body.div.div.a['href']
+        resp = self._req(new_url, remote_user='admin')
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.html.head.title.string, 'Pyramid Debug Toolbar')
+
+    def test_unauthenticated_toolbar_views(self):
+        resp = self._req('/hello/protected', remote_user='admin')
+        new_url = resp.html.body.div.div.a['href']
+        resp = self._req(new_url, remote_user=None, status=404)
+        # predicate mismatch appears because the valid_request predicate forbids access
+        self.assertTrue(b'predicate mismatch' in resp.body, 'incorrect body')
+        self.assertTrue(b'valid_request' in resp.body, 'incorrect body')


### PR DESCRIPTION
Also, adds tests for the auth system.

Closes #223.