### PR TITLE
Remove the query hash.

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -117,3 +117,4 @@ Contributors
 - Jonathan Vanasco, 2014-04-30
 - Marco Martinez, 2014-12-26
 - Jon Rosebaugh, 2015-05-21
+- Pieter Mulder, 2015-08-12

--- a/pyramid_debugtoolbar/panels/sqla.py
+++ b/pyramid_debugtoolbar/panels/sqla.py
@@ -103,15 +103,11 @@ class SQLADebugPanel(DebugPanel):
             except UnicodeDecodeError:
                 pass # parameters contain non-utf8 (probably binary) data
 
-            need = self.token + stmt + params
-            hash = hashlib.sha1(bytes_(need)).hexdigest()
-
             data.append({
                 'engine_id': query['engine_id'],
                 'duration': query['duration'],
                 'sql': format_sql(stmt),
                 'raw_sql': stmt,
-                'hash': hash,
                 'parameters': query['parameters'],
                 'params': params,
                 'is_select': is_select,


### PR DESCRIPTION
It is not used anymore and results in `UnicodDecode` exceptions when there
are unicode characters in the query statement