### PR TITLE
initial exception tracking

### DIFF
--- a/pyramid_debugtoolbar/__init__.py
+++ b/pyramid_debugtoolbar/__init__.py
@@ -22,6 +22,7 @@ from pyramid_debugtoolbar.toolbar import (IRequestAuthorization,
 toolbar_tween_factory = toolbar_tween_factory  # pyflakes
 
 default_panel_names = (
+    'pyramid_debugtoolbar.panels.exception.ExceptionDebugPanel',
     'pyramid_debugtoolbar.panels.headers.HeaderDebugPanel',
     'pyramid_debugtoolbar.panels.logger.LoggingPanel',
     'pyramid_debugtoolbar.panels.performance.PerformanceDebugPanel',

--- a/pyramid_debugtoolbar/panels/exception.py
+++ b/pyramid_debugtoolbar/panels/exception.py
@@ -1,0 +1,36 @@
+from pyramid_debugtoolbar.panels import DebugPanel
+from pyramid_debugtoolbar.compat import text_
+import re
+
+
+_ = lambda x: x
+
+
+REGEX_traceback_message = re.compile("""URL to recover this traceback page: <a href="(?P<url_encoded>[^"]*)">(?P<url_raw>[^"]*)</a>""", re.I)
+
+
+class ExceptionDebugPanel(DebugPanel):
+    """
+    A panel to display exception data
+    """
+    name = 'exception'
+    template = 'pyramid_debugtoolbar.panels:templates/exception.dbtmako'
+    title = _('Exception')
+    nav_title = title
+    
+    traceback_url = None
+
+    def __init__(self, request):
+        pass
+
+    def process_response(self, response):
+        t = response.text
+        if t:
+            exceptions = REGEX_traceback_message.findall(t)
+            if exceptions:
+                self.traceback_url = exceptions[0][1]  # use the url_raw of the first match
+        self.data = {'traceback_url': self.traceback_url}
+
+    @property
+    def has_content(self):
+        return bool(self.traceback_url)

--- a/pyramid_debugtoolbar/panels/templates/exception.dbtmako
+++ b/pyramid_debugtoolbar/panels/templates/exception.dbtmako
@@ -1,0 +1,7 @@
+<h4>Exception!</h4>
+<p>
+	It looks like this page generated an exception:
+</p>
+<ul class="list">
+	<li><a href="${traceback_url}">${traceback_url}</a></li>
+</ul>

--- a/pyramid_debugtoolbar/toolbar.py
+++ b/pyramid_debugtoolbar/toolbar.py
@@ -41,6 +41,7 @@ class DebugToolbar(object):
         self.request = request
         self.status_int = 200
         self.default_active_panels = default_active_panels
+        self.exception_url = None
 
         # Panels can be be activated (more features) (e.g. Performace panel)
         pdtb_active = url_unquote(request.cookies.get('pdtb_active', ''))
@@ -207,6 +208,7 @@ def toolbar_tween_factory(handler, registry, _logger=None):
                 exc_url = debug_toolbar_url(request, 'exception', _query=qs)
                 exc_msg = msg % (request.url, exc_url)
                 _logger.exception(exc_msg)
+                toolbar.exception_url = exc_url
 
                 subenviron = request.environ.copy()
                 del subenviron['PATH_INFO']


### PR DESCRIPTION
This is a first (working) attempt at enabling exception into on the toolbar (see https://github.com/Pylons/pyramid_debugtoolbar/issues/231)

This works by providing a new panel (Exception) which uses a regex on the response to look for the traceback url format.  If found, the 'has_content' is true and the panel links to the traceback page.

I had wanted to implement a better approach in `toolbar.py` that tracks the exception url once generated, however I couldn't find a good way to get that data into the panel.  I've left the exception_url as a property set on the `DebugToolbar` class for the future as well.