### PR TITLE
Update toolbar.js

### DIFF
--- a/pyramid_debugtoolbar/static/js/toolbar.js
+++ b/pyramid_debugtoolbar/static/js/toolbar.js
@@ -59,7 +59,7 @@ $('#settings .switchable').click(function() {
   }
 });
 
-// $(".pDebugSortable").tablesorter();
+ $(".pDebugSortable").tablesorter();
 
 bootstrap_panels = ['pDebugVersionPanel', 'pDebugHeaderPanel']
 


### PR DESCRIPTION
(Re)Enable table sorting.  Per Issue #148 , table sorting would be very useful.   Enabling table sorting works like a champ on Chrome v46 on Mac (El Capitan).  