### PR TITLE
added Location to Versions panel

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,10 @@
+unreleased
+==========
+
+- Added the packages' `.location` to the "Versions" panel so developers can tell
+  which version of each package is actually being used.
+  See https://github.com/Pylons/pyramid_debugtoolbar/pull/240
+
 2.4.2 (2015-10-28)
 ------------------
 

--- a/pyramid_debugtoolbar/panels/templates/versions.dbtmako
+++ b/pyramid_debugtoolbar/panels/templates/versions.dbtmako
@@ -8,6 +8,7 @@
 		<tr>
 			<th>Package Name</th>
 			<th>Version</th>
+			<th>Location</th>
 		</tr>
 	</thead>
 	<tbody>
@@ -15,6 +16,7 @@
 			<tr>
 				<td>${package['name']|h}</td>
 				<td>${package['version']|h}</td>
+				<td>${package['location']|h}</td>
 			</tr>
 		% endfor
 	</tbody>

--- a/pyramid_debugtoolbar/panels/versions.py
+++ b/pyramid_debugtoolbar/panels/versions.py
@@ -11,8 +11,10 @@ packages = []
 for distribution in pkg_resources.working_set:
     name = distribution.project_name
     packages.append({'version': distribution.version,
+                     'location': distribution.location,
                      'lowername': name.lower(),
-                     'name': name})
+                     'name': name,
+                     })
 
 packages = sorted(packages, key=itemgetter('lowername'))
 pyramid_version = pkg_resources.get_distribution('pyramid').version
@@ -30,7 +32,9 @@ class VersionDebugPanel(DebugPanel):
     nav_title = title
 
     def __init__(self, request):
-        self.data = {'platform': self.get_platform(), 'packages': packages}
+        self.data = {'platform': self.get_platform(),
+                     'packages': packages,
+                     }
 
     def _get_platform_name(self):
         return platform.platform()


### PR DESCRIPTION
I found it increasingly difficult to tell which version of a package was being used (the official release in my virtualenv or a forked version via `setup.py develop`).  

Simple fix - add the package's `location` to the "Versions" panel.