### PR TITLE
refactor the toolbar out of the parent app

### DIFF
--- a/pyramid_debugtoolbar/__init__.py
+++ b/pyramid_debugtoolbar/__init__.py
@@ -1,7 +1,5 @@
 from pyramid.config import Configurator
-from pyramid.security import NO_PERMISSION_REQUIRED
 from pyramid.settings import asbool
-from pyramid.wsgi import wsgiapp2
 from pyramid_debugtoolbar.utils import (
     as_cr_separated_list,
     as_display_debug_or_false,
@@ -14,9 +12,13 @@ from pyramid_debugtoolbar.utils import (
     SETTINGS_PREFIX,
     STATIC_PATH,
 )
-from pyramid_debugtoolbar.toolbar import (IRequestAuthorization,
-                                          toolbar_tween_factory)  # API
-toolbar_tween_factory = toolbar_tween_factory  # pyflakes
+from pyramid_debugtoolbar.toolbar import (
+    IRequestAuthorization,
+    IToolbarWSGIApp,
+    toolbar_tween_factory,
+)
+
+toolbar_tween_factory = toolbar_tween_factory  # API
 
 default_panel_names = (
     'pyramid_debugtoolbar.panels.headers.HeaderDebugPanel',
@@ -124,8 +126,6 @@ def includeme(config):
     # Update the current registry with the new settings
     config.registry.settings.update(settings)
 
-    config.include('pyramid_mako')
-    config.add_mako_renderer('.dbtmako', settings_prefix='dbtmako.')
     config.add_tween('pyramid_debugtoolbar.toolbar_tween_factory')
     config.add_subscriber(
         'pyramid_debugtoolbar.toolbar.beforerender_subscriber',
@@ -138,12 +138,13 @@ def includeme(config):
 
     # Create the new application using the updated settings
     application = make_application(settings, config.registry)
-    config.add_route('debugtoolbar', '/_debug_toolbar/*subpath')
-    config.add_view(wsgiapp2(application), route_name='debugtoolbar',
-                    permission=NO_PERMISSION_REQUIRED)
-    config.add_static_view('/_debug_toolbar/static', STATIC_PATH, static=True)
-    config.introspection = introspection
+    config.registry.registerUtility(application, IToolbarWSGIApp)
 
+    # register routes and views that can be used within the tween
+    config.add_route('debugtoolbar', '/_debug_toolbar/*subpath', static=True)
+    config.add_static_view('/_debug_toolbar/static', STATIC_PATH, static=True)
+
+    config.introspection = introspection
 
 def make_application(settings, parent_registry):
     """ WSGI application for rendering the debug toolbar."""
@@ -157,11 +158,15 @@ def make_application(settings, parent_registry):
     config.add_route('debugtoolbar.source', '/source')
     config.add_route('debugtoolbar.execute', '/execute')
     config.add_route('debugtoolbar.console', '/console')
+    config.add_route('debugtoolbar.redirect', '/redirect')
     config.add_route(EXC_ROUTE_NAME, '/exception')
-    config.add_route('debugtoolbar.sql_select', '/{request_id}/sqlalchemy/select/{query_index}')
-    config.add_route('debugtoolbar.sql_explain', '/{request_id}/sqlalchemy/explain/{query_index}')
+    config.add_route(
+        'debugtoolbar.sql_select',
+        '/{request_id}/sqlalchemy/select/{query_index}')
+    config.add_route(
+        'debugtoolbar.sql_explain',
+        '/{request_id}/sqlalchemy/explain/{query_index}')
     config.add_route('debugtoolbar.request', '/{request_id}')
     config.add_route('debugtoolbar.main', '/')
     config.scan('pyramid_debugtoolbar.views')
-
     return config.make_wsgi_app()

--- a/pyramid_debugtoolbar/utils.py
+++ b/pyramid_debugtoolbar/utils.py
@@ -202,10 +202,20 @@ def find_request_history(request):
 def debug_toolbar_url(request, *elements, **kw):
     return request.route_url('debugtoolbar', subpath=elements, **kw)
 
-
 def hexlify(value):
     """Hexlify int, str then returns native str type."""
     # If integer
     str_ = str(value)
     hexified = text_(binascii.hexlify(bytes_(str_)))
     return hexified
+
+def make_subrequest(request, root_path, path, params=None):
+    # we know root_path will have a trailing slash and
+    # path will need one
+    subrequest = type(request).blank(
+        '/' + path,
+        base_url=request.application_url + root_path[:-1],
+    )
+    if params is not None:
+        subrequest.GET.update(params)
+    return subrequest

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -51,8 +51,8 @@ class Test_auth(unittest.TestCase):
         self.assertEqual(resp.content_type, 'text/html')
         self.assertEqual(resp.html.body.string, 'Hello pyramid!')
         # Python 2.6 doesn't include assertIsNone or other useful asserts. Sigh.
-        self.assertTrue(resp.html.body.script is None, 'not None')
-        self.assertTrue(resp.html.body.div is None, 'not None')
+        self.assertTrue(resp.html.body.script is None)
+        self.assertTrue(resp.html.body.div is None)
 
     def test_authenticated_toolbar_injection(self):
         resp = self._req('/hello/secrets', remote_user='admin')
@@ -60,7 +60,7 @@ class Test_auth(unittest.TestCase):
         # dive into the request history stored by the toolbar tween
         request_id = self.testapp.app.registry.request_history[0][0]
         # check it against the link in the injected html
-        self.assertTrue(request_id in resp.html.body.div.div.a['href'], 'request_id not found in html')
+        self.assertTrue(request_id in resp.html.body.div.div.a['href'])
 
     def test_authenticated_toolbar_views(self):
         resp = self._req('/hello/rumors', remote_user='admin')
@@ -73,4 +73,4 @@ class Test_auth(unittest.TestCase):
         resp = self._req('/hello/protected', remote_user='admin')
         new_url = resp.html.body.div.div.a['href']
         resp = self._req(new_url, remote_user=None, status=404)
-        self.assertTrue(b'client authorization failed' in resp.body, 'incorrect body')
+        self.assertTrue(b'404 Not Found' in resp.body)


### PR DESCRIPTION
The tween will now dispatch directly to the toolbar for content instead of invoking subrequests into the parent application.

The benefits of this approach are that we are no longer subject to any odd configuration in the parent app that may affect the toolbar's view.

The toolbar was also registering pyramid_mako and was using the parent app to actually render the redirect interceptions and all of the exception views. I moved things around such that the toolbar app is now always used for rendering instead of the parent app.