### PR TITLE
ensured path is a path,  not a url.

### DIFF
--- a/pyramid_debugtoolbar/panels/introspection.py
+++ b/pyramid_debugtoolbar/panels/introspection.py
@@ -35,7 +35,7 @@ class IntrospectionDebugPanel(DebugPanel):
             'nl2br': nl2br}
 
     def render_vars(self, request):
-        return {'static_path': request.static_url(STATIC_PATH)}
+        return {'static_path': request.static_path(STATIC_PATH)}
 
 
 def nl2br(s):

--- a/pyramid_debugtoolbar/panels/sqla.py
+++ b/pyramid_debugtoolbar/panels/sqla.py
@@ -129,6 +129,6 @@ class SQLADebugPanel(DebugPanel):
         return {
             'pdtb_id': self.pdtb_id,
             'route_url': request.route_url,
-            'static_path': request.static_url(STATIC_PATH),
-            'root_path': request.route_url(ROOT_ROUTE_NAME)
+            'static_path': request.static_path(STATIC_PATH),
+            'root_path': request.route_path(ROOT_ROUTE_NAME)
         }

--- a/pyramid_debugtoolbar/panels/traceback.py
+++ b/pyramid_debugtoolbar/panels/traceback.py
@@ -50,8 +50,8 @@ class TracebackPanel(DebugPanel):
 
     def render_vars(self, request):
         return {
-            'static_path': request.static_url(STATIC_PATH),
-            'root_path': request.route_url(ROOT_ROUTE_NAME),
+            'static_path': request.static_path(STATIC_PATH),
+            'root_path': request.route_path(ROOT_ROUTE_NAME),
 
             # render the summary using the toolbar's request object, not
             # the original request that generated the traceback!

--- a/pyramid_debugtoolbar/panels/tweens.py
+++ b/pyramid_debugtoolbar/panels/tweens.py
@@ -36,5 +36,5 @@ class TweensDebugPanel(DebugPanel):
             }
 
     def render_vars(self, request):
-        return {'static_path': request.static_url(STATIC_PATH)}
+        return {'static_path': request.static_path(STATIC_PATH)}
 

--- a/pyramid_debugtoolbar/tbtools.py
+++ b/pyramid_debugtoolbar/tbtools.py
@@ -235,8 +235,8 @@ class Traceback(object):
 
     def render_full(self, request, lodgeit_url=None):
         """Render the Full HTML page with the traceback info."""
-        static_path = request.static_url(STATIC_PATH)
-        root_path = request.route_url(ROOT_ROUTE_NAME)
+        static_path = request.static_path(STATIC_PATH)
+        root_path = request.route_path(ROOT_ROUTE_NAME)
         exc = escape(self.exception)
         summary = self.render_summary(include_title=False, request=request)
         token = request.registry.parent_registry.pdtb_token

--- a/pyramid_debugtoolbar/toolbar.py
+++ b/pyramid_debugtoolbar/toolbar.py
@@ -97,7 +97,7 @@ class DebugToolbar(object):
         toolbar_url = debug_toolbar_url(request, request.pdtb_id)
         button_style = get_setting(request.registry.settings,
                                    'button_style', '')
-        css_path = request.static_url(
+        css_path = request.static_path(
             STATIC_PATH + 'toolbar/toolbar_button.css')
         toolbar_html = toolbar_html_template % {
             'button_style': (

--- a/pyramid_debugtoolbar/views.py
+++ b/pyramid_debugtoolbar/views.py
@@ -72,8 +72,8 @@ class ExceptionDebugView(object):
         renderer='pyramid_debugtoolbar:templates/console.dbtmako',
     )
     def console(self):
-        static_path = self.request.static_url(STATIC_PATH)
-        toolbar_root_path = self.request.route_url(ROOT_ROUTE_NAME)
+        static_path = self.request.static_path(STATIC_PATH)
+        toolbar_root_path = self.request.route_path(ROOT_ROUTE_NAME)
         exc_history = self.exc_history
         vars = {
             'evalex':           exc_history.eval_exc and 'true' or 'false',
@@ -193,8 +193,8 @@ def request_view(request):
     request_id = request.matchdict.get('request_id', last_request_id)
     toolbar = history.get(request_id, None)
 
-    static_path = request.static_url(STATIC_PATH)
-    root_path = request.route_url(ROOT_ROUTE_NAME)
+    static_path = request.static_path(STATIC_PATH)
+    root_path = request.route_path(ROOT_ROUTE_NAME)
     
     button_style = get_setting(request.registry.settings,
             'button_style')


### PR DESCRIPTION
The current toolbar sets variables in the template scope such as `static_path` and `root_path`.  In several instances, they are not "paths", but entire URLs via calls to `static_url` or `root_url`.

This patch ensures the templates receive a `path` or `url` as expected by the semantically named variable.

The reason for this patch:  I believe this is an effect of the recent-ish splitting of the toolbar into its own application.  The debugtoolbar can only know if a url is served via `https` if the environment variables are transitioned in wsgi middleware (ie, if the environment variables are modified in the application via subscribers, this will not be known).  Without middleware, the existing toolbar will think requests served behind an HTTPS proxy are HTTP and include/link to the HTTP paths because a URL is used where a PATH is expected, breaking css and javascript.   By using a path instead of a route, a `https` site will link to `/_debugtoolbar/asset` instead of `http://example.com/_debugtoolbar/asset`
