### PR TITLE
add a new add_debugtoolbar_panel directive to the toolbar app

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -9,6 +9,8 @@
 
 .. autofunction:: toolbar_tween_factory
 
+.. autofunction:: add_debugtoolbar_panel
+
 .. automodule:: pyramid_debugtoolbar.panels
 
 .. autoclass:: DebugPanel

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -222,8 +222,8 @@ file.
 
   The debugtoolbar will use Pyramid's default
   :meth:`pyramid.config.Configurator.include` mechanism to extend the toolbar's
-  internal Pyramid application with custom logic. This is a good spot to affect
-  static assets used by the toolbar, or add custom urls.
+  internal Pyramid application with custom logic. This is a good spot to add
+  custom panels, affect static assets used by the toolbar, or add custom urls.
 
 Useful settings for debugging panels/debugtoolbar
 `````````````````````````````````````````````````
@@ -556,7 +556,7 @@ sample panel:
            return _('Sample')
 
    def includeme(config):
-       config.registry.settings['debugtoolbar.panels'].append(SampleDebugPanel)
+       config.add_debugtoolbar_panel(SampleDebugPanel)
 
 After inheriting from the DebugPanel class, you have to define a few methods and
 attributes on your panel:
@@ -666,10 +666,12 @@ Configuring an application to use the panel
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Once your panel is ready, you can simply add its package name to the
-``pyramid.includes`` setting on your application configuration file::
+``debugtoolbar.includes`` setting on your application configuration file::
 
   pyramid.includes =
       pyramid_debugtoolbar
+
+  debugtoolbar.includes =
       samplepanel
 
 JavaScript and CSS Available to Custom Panels

--- a/pyramid_debugtoolbar/__init__.py
+++ b/pyramid_debugtoolbar/__init__.py
@@ -6,7 +6,6 @@ from pyramid_debugtoolbar.utils import (
     as_globals_list,
     as_int,
     as_list,
-    as_verbatim,
     EXC_ROUTE_NAME,
     ROOT_ROUTE_NAME,
     SETTINGS_PREFIX,
@@ -51,7 +50,8 @@ default_settings = [
     ('extra_global_panels', as_globals_list, ()),
     ('hosts', as_list, default_hosts),
     ('exclude_prefixes', as_cr_separated_list, []),
-    ('active_panels', as_list, []),
+    ('active_panels', as_list, ()),
+    ('includes', as_list, ()),
     ('button_style', None, ''),
     ('max_request_history', as_int, 100),
     ('max_visible_requests', as_int, 10),
@@ -64,7 +64,6 @@ default_transform = [
     # name, convert, default
     ('debug_notfound', asbool, 'false'),
     ('debug_routematch', asbool, 'false'),
-    ('includes', as_verbatim, ()),
     ('prevent_http_cache', asbool, 'false'),
     ('reload_assets', asbool, 'false'),
     ('reload_resources', asbool, 'false'),
@@ -126,19 +125,23 @@ def includeme(config):
     # Update the current registry with the new settings
     config.registry.settings.update(settings)
 
-    config.add_tween('pyramid_debugtoolbar.toolbar_tween_factory')
-    config.add_subscriber(
-        'pyramid_debugtoolbar.toolbar.beforerender_subscriber',
-        'pyramid.events.BeforeRender')
-    config.add_directive('set_debugtoolbar_request_authorization',
-                         set_request_authorization_callback)
-
     # Do the transform and update the settings dictionary
     settings.update(transform_settings(settings))
 
-    # Create the new application using the updated settings
+    # Create the toolbar application using the updated settings
+    # Do this before adding the tween, etc to give debugtoolbar.includes
+    # a chance to affect the settings beforehand incase autocommit is
+    # enabled
     application = make_application(settings, config.registry)
     config.registry.registerUtility(application, IToolbarWSGIApp)
+
+    config.add_tween('pyramid_debugtoolbar.toolbar_tween_factory')
+    config.add_subscriber(
+        'pyramid_debugtoolbar.toolbar.beforerender_subscriber',
+        'pyramid.events.BeforeRender',
+    )
+    config.add_directive('set_debugtoolbar_request_authorization',
+                         set_request_authorization_callback)
 
     # register routes and views that can be used within the tween
     config.add_route('debugtoolbar', '/_debug_toolbar/*subpath', static=True)
@@ -151,6 +154,7 @@ def make_application(settings, parent_registry):
     config = Configurator(settings=settings)
     config.registry.parent_registry = parent_registry
     config.include('pyramid_mako')
+    config.add_directive('add_debugtoolbar_panel', add_debugtoolbar_panel)
     config.add_mako_renderer('.dbtmako', settings_prefix='dbtmako.')
     config.add_static_view('static', STATIC_PATH)
     config.add_route(ROOT_ROUTE_NAME, '/', static=True)
@@ -169,4 +173,45 @@ def make_application(settings, parent_registry):
     config.add_route('debugtoolbar.request', '/{request_id}')
     config.add_route('debugtoolbar.main', '/')
     config.scan('pyramid_debugtoolbar.views')
+
+    # commit the toolbar config and include any user-defined includes
+    config.commit()
+
+    includes = settings.get(SETTINGS_PREFIX + 'includes', ())
+    for include in includes:
+        config.include(include)
+
     return config.make_wsgi_app()
+
+def add_debugtoolbar_panel(config, panel_factory, is_global=False):
+    """
+    A Pyramid config directive accessible as ``config.add_debugtoolbar_panel``.
+
+    This directive can add a new panel to the toolbar application. It should
+    be used from includeme functions via the ``debugtoolbar.includes`` setting.
+
+    The ``panel_factory`` should be a factory that accepts a ``request``
+    object and returns a subclass of
+    :class:`pyramid_debugtoolbar.panels.DebugPanel`.
+
+    If ``is_global`` is ``True`` then the panel will be added to the global
+    panel list which includes application-wide panels that do not depend
+    on per-request data to operate.
+
+    """
+    parent_settings = config.registry.parent_registry.settings
+    if is_global:
+        default_setting = SETTINGS_PREFIX + 'global_panels'
+        extra_setting = SETTINGS_PREFIX + 'extra_global_panels'
+    else:
+        default_setting = SETTINGS_PREFIX + 'panels'
+        extra_setting = SETTINGS_PREFIX + 'extra_panels'
+    default_panels = parent_settings.get(default_setting, [])
+    extra_panels = parent_settings.setdefault(extra_setting, [])
+
+    # only add the panel if it wasn't added manually in an explicit order
+    if (
+        panel_factory not in extra_panels and
+        panel_factory not in default_panels
+    ):
+        default_panels.append(panel_factory)

--- a/pyramid_debugtoolbar/toolbar.py
+++ b/pyramid_debugtoolbar/toolbar.py
@@ -118,7 +118,7 @@ class ExceptionHistory(object):
 
 
 def beforerender_subscriber(event):
-    request = event['request']
+    request = event.get('request')
     if request is None:
         request = get_current_request()
     if getattr(request, 'debug_toolbar', None) is not None:

--- a/pyramid_debugtoolbar/utils.py
+++ b/pyramid_debugtoolbar/utils.py
@@ -147,8 +147,11 @@ def as_list(value):
     values = as_cr_separated_list(value)
     result = []
     for value in values:
-        subvalues = value.split()
-        result.extend(subvalues)
+        if isinstance(value, string_types):
+            subvalues = value.split()
+            result.extend(subvalues)
+        else:
+            result.append(value)
     return result
 
 def as_globals_list(value):
@@ -168,8 +171,6 @@ def as_display_debug_or_false(value):
     if b: # bw compat for dbt <=0.9
         return 'debug'
     return False
-
-as_verbatim = lambda v: v
 
 def get_setting(settings, name, default=None):
     return settings.get('%s%s' % (SETTINGS_PREFIX, name), default)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -51,7 +51,7 @@ class Test_parse_settings(unittest.TestCase):
                           'debugtoolbar.reload_assets': False,
                           'debugtoolbar.prevent_http_cache': False,
                           'debugtoolbar.active_panels': ['dummy_panel'],
-                          'debugtoolbar.includes': (),
+                          'debugtoolbar.includes': [],
                           'debugtoolbar.button_style': '',
                           'debugtoolbar.max_request_history': 100,
                           'debugtoolbar.max_visible_requests': 10,

--- a/tests/test_toolbar.py
+++ b/tests/test_toolbar.py
@@ -81,8 +81,8 @@ class Test_beforerender_subscriber(unittest.TestCase):
     def setUp(self):
         self.request = Request.blank('/')
         self.config = testing.setUp(request=self.request)
-        panel = DummyPanel(self.request)
-        self.request.debug_toolbar = DummyToolbar([panel])
+        self.panel = DummyPanel(self.request)
+        self.request.debug_toolbar = DummyToolbar([self.panel])
 
     def tearDown(self):
         testing.tearDown()


### PR DESCRIPTION
This is useful for extensions that wish to define their own includeme
that is added via ``debugtoolbar.includes``. An extension can now
register its own panel.

This should become the primary way of defining toolbar panels because the panel can be added in conjunction with other configuration such as urls and static assets if necessary. For example:

```python
def includeme(config):
    config.add_debugtoolbar_panel(panel)
    config.add_static_view(...)
    config.add_route(...)
    config.add_view(...)
```

These routes and views are now accessible within the toolbar app at `http://localhost:6543/_debug_toolbar/...`.