### PR TITLE
updated stickypanel to address current id

### DIFF
--- a/pyramid_debugtoolbar/static/toolbar/toolbar.js
+++ b/pyramid_debugtoolbar/static/toolbar/toolbar.js
@@ -234,7 +234,7 @@ $(function() {
 
 	// subscribe panels for recording the active panel in a cookie
 	$(".pDebugPanels ul li a").click(function() {
-		var selected_panel_text = $(this).attr('id');
+		var selected_panel_text = $(this).parent().attr('id');
 		if (selected_panel_text){
 			$.cookie(COOKIE_NAME_STICKYPANEL_SELECTED, selected_panel_text);
 		}


### PR DESCRIPTION
There was a slight change in one of the recent mako templates the broke the sticky panel functionality.  This restores it.