### PR TITLE
logger sorting

### DIFF
--- a/pyramid_debugtoolbar/panels/logger.py
+++ b/pyramid_debugtoolbar/panels/logger.py
@@ -66,8 +66,7 @@ class LoggingPanel(DebugPanel):
     def has_content(self):
         if self.data.get('records'):
             return True
-        else:
-            return False
+        return False
 
     def get_and_delete(self):
         records = handler.get_records()
@@ -77,7 +76,8 @@ class LoggingPanel(DebugPanel):
     @property
     def nav_subtitle(self):
         if self.data:
-            return '%d' % len(self.data.get('records'))
+            return '%d/%d' % (len([i for i in self.data.get('records') if i['level'] != 'DEBUG']),
+                              len(self.data.get('records')))
 
 def includeme(config):
     config.add_debugtoolbar_panel(LoggingPanel)

--- a/pyramid_debugtoolbar/panels/templates/logger.dbtmako
+++ b/pyramid_debugtoolbar/panels/templates/logger.dbtmako
@@ -1,4 +1,28 @@
 % if records:
+
+	<form class="form-inline">
+	  <div class="form-group">
+		<label for="logger-search">Message Filter</label>
+		<input class="form-control" id="logger-search" placeholder="Type To Filter">
+		<script type="text/javascript">
+			$("#logger-search").keyup(function () {
+				var rows = $("#logger-lines").find("tr").hide();
+				if (this.value.length) {
+					var data = this.value.split(" ");
+					$.each(data, function (i, v) {
+						rows.find("td.msg:contains('" + v + "')").parent().show();
+					});
+				} else rows.show();
+			});
+		</script>
+	  </div>
+	  <div class="form-group">
+		<label for="logger-search">or Message Level</label>
+		<select class="form-control" id="logger-level">
+			<option value="all">All</option>
+		</select>
+	  </div>
+	</form>	
 	<table class="table table-striped table-condensed">
 		<thead>
 			<tr>
@@ -8,17 +32,39 @@
 				<th>Location</th>
 			</tr>
 		</thead>
-		<tbody>
+		<tbody id="logger-lines">
+			<% logger_levels = {} %>
 			% for i, record in enumerate(records):
-				<tr>
-					<td>${record['level']}</td>
+				<%
+					lvl = record['level']
+					if lvl not in logger_levels:
+						logger_levels[lvl] = 0
+					logger_levels[lvl] += 1
+				%>
+				<tr data-level="${record['level']}">
+					<td><code>${record['level']}</code></td>
 					<td>${record['time']}</td>
-					<td>${record['message']}</td>
+					<td class="msg">${record['message']}</td>
 					<td title="${record['file_long']}:${record['line']}">${record['file']}:${record['line']}</td>
 				</tr>
 			% endfor
 		</tbody>
 	</table>
+	<script type="text/javascript">
+		var logger_level = $("#logger-level");
+		## build the <options> in python, insert in javascript
+		% for lvl, cnt in logger_levels.items():
+			<% opt = """<option value='%s'> %s - %s</option>""" % (lvl, lvl, cnt) %>
+			logger_level.append("${opt|n}");
+		% endfor
+		logger_level.change(function () {
+			var rows = $("#logger-lines").find("tr").hide();
+			var lvl = this.value;
+			if (lvl != 'all') {
+				$("#logger-lines").find("tr[data-level='" + lvl + "']").show();
+			} else rows.show();
+		});
+	</script>
 % else:
 	<p>No messages logged.</p>
 % endif


### PR DESCRIPTION
This is an idea on how to handle the following tickets:

* https://github.com/Pylons/pyramid_debugtoolbar/issues/111
* https://github.com/Pylons/pyramid_debugtoolbar/issues/94

It does 3 things:

* the subnav on the panel title is a fraction of "non-debug/all" messages.  so 100 debug-only messages will appear as "0/100", but 10 critical/warning/etc were added it would be "10/110"
* the table has a javascript filter that only shows messages of a certain level. 
* the table has a javascript filter for text in the message

this was just a quick proof-of-concept. things I don't particularly like:

* counting the debug lines in the subnav
* building options in python/mako then displaying in javascript