### PR TITLE
fix #302: show warning instead of 404 for orphaned debug sessions

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -119,3 +119,4 @@ Contributors
 - Jon Rosebaugh, 2015-05-21
 - Pieter Mulder, 2015-08-12
 - Kashif Iftikhar, 2016-07-01
+- Dan Clark, 2017-05-22

--- a/pyramid_debugtoolbar/templates/history_tab.dbtmako
+++ b/pyramid_debugtoolbar/templates/history_tab.dbtmako
@@ -13,8 +13,11 @@
     <div class="col-sm-9 col-sm-offset-3 col-md-10 col-md-offset-2 main">
     <div class="pDebugPanels">
         <ul class="nav nav-tabs">
-          % if not panels:
+          % if not panels and not request_id:
           <li class="pDebugButton">DEBUG</li>
+          % endif
+          % if request_id and not panels:
+          <p>Warning: The request has been lost due to an application reset.</p>
           % endif
           % for panel in panels:
           <% _css_class = 'disabled' if not panel.has_content else '' %>

--- a/pyramid_debugtoolbar/toolbar_app.py
+++ b/pyramid_debugtoolbar/toolbar_app.py
@@ -54,8 +54,7 @@ def make_toolbar_app(settings, parent_registry):
     config.add_route(ROOT_ROUTE_NAME, '/', static=True)
     config.add_route('debugtoolbar.sse', '/sse')
     config.add_route('debugtoolbar.redirect', '/redirect')
-    config.add_route('debugtoolbar.request', '/{request_id}',
-                     history_request=True)
+    config.add_route('debugtoolbar.request', '/{request_id}')
     config.add_route('debugtoolbar.main', '/')
     config.scan(__name__)
 


### PR DESCRIPTION
* Removed route predicate on the debugtoolbar.request route to prevent 404.
* Added logic into template to show warning.