### PR TITLE
Fix broken exception handling introduced by PR #303

### DIFF
--- a/pyramid_debugtoolbar/panels/traceback.py
+++ b/pyramid_debugtoolbar/panels/traceback.py
@@ -51,7 +51,6 @@ class TracebackPanel(DebugPanel):
 
         # stop hanging onto the request after the response is processed
         del self.request
-
     def render_vars(self, request):
         return {
             'static_path': request.static_url(STATIC_PATH),
@@ -70,7 +69,7 @@ class ExceptionDebugView(object):
         if exc_history is None:
             raise HTTPBadRequest('No exception history')
         self.exc_history = exc_history
-        token = self.request.params.get('token')
+        token = self.request.matchdict.get('token')
         if not token:
             raise HTTPBadRequest('No token in request')
         if not token == request.registry.parent_registry.pdtb_token:
@@ -115,9 +114,9 @@ class ExceptionDebugView(object):
         return HTTPBadRequest()
 
 def includeme(config):
-    config.add_route(EXC_ROUTE_NAME, '/exception')
-    config.add_route('debugtoolbar.source', '/source')
-    config.add_route('debugtoolbar.execute', '/execute')
+    config.add_route(EXC_ROUTE_NAME, '/exception/{token}')
+    config.add_route('debugtoolbar.source', '/source/{token}')
+    config.add_route('debugtoolbar.execute', '/execute/{token}')
 
     config.add_debugtoolbar_panel(TracebackPanel)
     config.scan(__name__)

--- a/pyramid_debugtoolbar/tbtools.py
+++ b/pyramid_debugtoolbar/tbtools.py
@@ -240,8 +240,8 @@ class Traceback(object):
         exc = escape(self.exception)
         summary = self.render_summary(include_title=False, request=request)
         token = request.registry.parent_registry.pdtb_token
-        qs = {'token': token, 'tb': str(self.id)}
-        url = request.route_url(EXC_ROUTE_NAME, _query=qs)
+        qs = {'tb': str(self.id)}
+        url = request.route_url(EXC_ROUTE_NAME, token=token, _query=qs)
         evalex = request.exc_history.eval_exc
         vars = {
             'evalex':           evalex and 'true' or 'false',

--- a/pyramid_debugtoolbar/toolbar.py
+++ b/pyramid_debugtoolbar/toolbar.py
@@ -188,7 +188,10 @@ def toolbar_tween_factory(handler, registry, _logger=None, _dispatch=None):
 
     dispatch = lambda request: _dispatch(toolbar_app, request)
 
-    def toolbar_tween(request):
+    def append_token(path, token):
+        return path + '/' + token
+
+    def toolbar_tween(request, path_helper=append_token):
         try:
             p = request.path_info
         except UnicodeDecodeError as e:
@@ -254,9 +257,9 @@ def toolbar_tween_factory(handler, registry, _logger=None, _dispatch=None):
                 request.pdbt_tb = tb
 
                 msg = 'Exception at %s\ntraceback url: %s'
-                qs = {'token': registry.pdtb_token, 'tb': str(tb.id)}
+                qs = {'tb': str(tb.id)}
                 subrequest = make_subrequest(
-                    request, root_path, 'exception', qs)
+                    request, root_path, path_helper('exception', registry.pdtb_token), qs)
                 exc_msg = msg % (request.url, subrequest.url)
                 _logger.exception(exc_msg)
 

--- a/tests/test_toolbar.py
+++ b/tests/test_toolbar.py
@@ -203,6 +203,7 @@ class Test_toolbar_handler(unittest.TestCase):
         registry = self.config.registry
         def dispatcher(app, request):
             request.registry = registry.parent_registry = registry
+            request.matchdict = {'token': request.registry.parent_registry.pdtb_token} 
             request.exc_history = registry.exc_history
             return ExceptionDebugView(request).exception()
         return dispatcher
@@ -294,7 +295,7 @@ class Test_toolbar_handler(unittest.TestCase):
             raise NotImplementedError
         self.config.registry.settings['debugtoolbar.intercept_exc'] = True
         self.config.registry.settings['debugtoolbar.secret'] = 'abc'
-        self.config.add_route('debugtoolbar.exception', '/exception')
+        self.config.add_route('debugtoolbar.exception', '/exception/{token}')
         request.registry = self.config.registry
         request.remote_addr = '127.0.0.1'
         logger = DummyLogger()
@@ -333,7 +334,7 @@ class Test_toolbar_handler(unittest.TestCase):
             raise NotImplementedError(b'K\xc3\xa4se!\xe2\x98\xa0')
         self.config.registry.settings['debugtoolbar.intercept_exc'] = True
         self.config.registry.settings['debugtoolbar.secret'] = 'abc'
-        self.config.add_route('debugtoolbar.exception', '/exception')
+        self.config.add_route('debugtoolbar.exception', '/exception/{token}')
         request.registry = self.config.registry
         request.remote_addr = '127.0.0.1'
         logger = DummyLogger()
@@ -353,7 +354,7 @@ class Test_toolbar_handler(unittest.TestCase):
         self.config.registry.settings['debugtoolbar.show_on_exc_only'] = True
         self.config.registry.settings['debugtoolbar.intercept_exc'] = True
         self.config.registry.settings['debugtoolbar.secret'] = 'abc'
-        self.config.add_route('debugtoolbar.exception', '/exception')
+        self.config.add_route('debugtoolbar.exception', '/exception/{token}')
         request.registry = self.config.registry
         request.remote_addr = '127.0.0.1'
         logger = DummyLogger()
@@ -371,7 +372,7 @@ class Test_toolbar_handler(unittest.TestCase):
         self.config.registry.settings['debugtoolbar.show_on_exc_only'] = True
         self.config.registry.settings['debugtoolbar.intercept_exc'] = True
         self.config.registry.settings['debugtoolbar.secret'] = 'abc'
-        self.config.add_route('debugtoolbar.exception', '/exception')
+        self.config.add_route('debugtoolbar.exception', '/exception/{token}')
         request.registry = self.config.registry
         request.remote_addr = '127.0.0.1'
         response = self._callFUT(request, handler)
@@ -388,7 +389,7 @@ class Test_toolbar_handler(unittest.TestCase):
         self.config.registry.settings['debugtoolbar.show_on_exc_only'] = False
         self.config.registry.settings['debugtoolbar.intercept_exc'] = True
         self.config.registry.settings['debugtoolbar.secret'] = 'abc'
-        self.config.add_route('debugtoolbar.exception', '/exception')
+        self.config.add_route('debugtoolbar.exception', '/exception/{token}')
         request.registry = self.config.registry
         request.remote_addr = '127.0.0.1'
         response = self._callFUT(request, handler)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -23,7 +23,7 @@ class TestExceptionDebugView(unittest.TestCase):
     def _makeRequest(self):
         request = testing.DummyRequest()
         request.secret = 'abc';
-        request.params['token'] = 'token'
+        request.matchdict['token'] = 'token'
         request.exc_history = self._makeExceptionHistory()
         return request
 
@@ -46,13 +46,12 @@ class TestExceptionDebugView(unittest.TestCase):
     def test_without_token_in_request(self):
         from pyramid.httpexceptions import HTTPBadRequest
         request = self._makeRequest()
-        del request.params['token']
+        del request.matchdict['token']
         self.assertRaises(HTTPBadRequest, self._makeOne, request)
-
     def test_with_bad_token_in_request(self):
         from pyramid.httpexceptions import HTTPBadRequest
         request = self._makeRequest()
-        request.params['token'] = 'wrong'
+        request.matchdict['token'] = 'wrong'
         self.assertRaises(HTTPBadRequest, self._makeOne, request)
 
     def test_source(self):


### PR DESCRIPTION
The original fix for #302 in PR #303 broke the exception panel as it caused exception requests to be caught by the wrong route. This fixes it by moving the token from the query string to the path.

And yes, the test now pass.