### PR TITLE
Fix tracebacks

### DIFF
--- a/demo/demo.py
+++ b/demo/demo.py
@@ -121,7 +121,7 @@ def make_app():
     settings['debugtoolbar.reload_templates'] = True
     settings['debugtoolbar.hosts'] = ['127.0.0.1']
     settings['debugtoolbar.intercept_redirects'] = True
-    settings['debugtoolbar.exclude_prefixes'] = ['/static']
+    settings['debugtoolbar.exclude_prefixes'] = ['/static', '/favicon.ico']
 
     # session factory
     session_factory = SignedCookieSessionFactory('itsaseekreet')

--- a/demo/demo.py
+++ b/demo/demo.py
@@ -36,9 +36,22 @@ log = logging.getLogger(__file__)
 
 here = os.path.dirname(os.path.abspath(__file__))
 
+@view_config(route_name='test_exc')
+def exc(request):
+    raise RuntimeError
+
 @view_config(route_name='test_squashed_exc')
 def squashed_exc(request):
     raise RuntimeError
+
+@view_config(
+    route_name='test_squashed_exc',
+    context=RuntimeError,
+    renderer='notfound.mako',
+)
+def notfound_view(request):
+    request.response.status_code = 404
+    return {}
 
 @view_config(route_name='test_notfound')
 def notfound(request):
@@ -53,11 +66,6 @@ def call_ajax(request):
     return {'ajax':'success'}
 
 @view_config(context=HTTPNotFound, renderer='notfound.mako')
-def notfound_view(request):
-    request.response.status_code = 404
-    return {}
-
-@view_config(context=RuntimeError, renderer='notfound.mako')
 def notfound_view(request):
     request.response.status_code = 404
     return {}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -206,11 +206,13 @@ file.
   by carriage returns. For example::
 
     debugtoolbar.exclude_prefixes =
+        /favicon.ico
         /settings
         /static
 
-  If configuration is done via Python, the setting should be a list.  This
-  setting was added in debugtoolbar version 1.0.4.
+  If configuration is done via Python, the setting should be a list.
+
+  By default, the setting is ``['/favicon.ico']``.
 
 ``debugtoolbar.active_panels``
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -124,16 +124,6 @@ file.
   handler.  Note that, for backwards compatibility purposes, the value
   ``true`` provided to this setting is interpreted as ``debug``.
 
-``debugtoolbar.eval_exc``
-
-  ``true`` if real-time exception debugging is enabled when
-  ``intercept_exc`` is true; ``false`` if real-time exception debugging is
-  disabled.  Default is ``true``.  This differs from
-  ``debugtoolbar.intercept_exc``: it only controls whether the pretty
-  exception rendering displays real-time in-browser debugging controls.  The
-  real-time in-browser debugging controls allow you to evaluate arbitrary
-  Python expresssions in the context of a stack frame via a browser control.
-
 ``debugtoolbar.show_on_exc_only``
 
   Default is ``false``. If set to ``true`` the debugtoolbar will only be

--- a/pyramid_debugtoolbar/__init__.py
+++ b/pyramid_debugtoolbar/__init__.py
@@ -33,7 +33,7 @@ default_settings = [
     ('global_panels', as_list, ()),
     ('extra_global_panels', as_list, ()),
     ('hosts', as_list, default_hosts),
-    ('exclude_prefixes', as_cr_separated_list, ()),
+    ('exclude_prefixes', as_cr_separated_list, ('/favicon.ico',)),
     ('active_panels', as_list, ()),
     ('includes', as_list, ()),
     ('button_style', None, ''),

--- a/pyramid_debugtoolbar/panels/sqla.py
+++ b/pyramid_debugtoolbar/panels/sqla.py
@@ -67,7 +67,6 @@ class SQLADebugPanel(DebugPanel):
             self.engines = request.registry.pdtb_sqla_engines
         else:
             self.engines = request.registry.pdtb_sqla_engines = {}
-        self.token = request.registry.pdtb_token
         self.pdtb_id = request.pdtb_id
 
     @property

--- a/pyramid_debugtoolbar/panels/sqla.py
+++ b/pyramid_debugtoolbar/panels/sqla.py
@@ -9,7 +9,6 @@ from pyramid.view import view_config
 from pyramid_debugtoolbar.compat import json
 from pyramid_debugtoolbar.compat import url_quote
 from pyramid_debugtoolbar.panels import DebugPanel
-from pyramid_debugtoolbar.utils import find_request_history
 from pyramid_debugtoolbar.utils import format_sql
 from pyramid_debugtoolbar.utils import text_
 from pyramid_debugtoolbar.utils import STATIC_PATH
@@ -132,9 +131,10 @@ class SQLAlchemyViews(object):
 
     def find_query(self):
         request_id = self.request.matchdict['request_id']
-        all_history = find_request_history(self.request)
-        history = all_history.get(request_id)
-        sqlapanel = [p for p in history.panels if p.name == 'sqlalchemy'][0]
+        toolbar = self.request.pdtb_history.get(request_id)
+        if toolbar is None:
+            raise HTTPBadRequest('No history found for request.')
+        sqlapanel = [p for p in toolbar.panels if p.name == 'sqlalchemy'][0]
         query_index = int(self.request.matchdict['query_index'])
         return sqlapanel.queries[query_index]
 

--- a/pyramid_debugtoolbar/panels/templates/traceback.dbtmako
+++ b/pyramid_debugtoolbar/panels/templates/traceback.dbtmako
@@ -67,8 +67,8 @@
       -->
 
     <script type="text/javascript">
-      var TRACEBACK = ${str(traceback_id)},
-          DEBUGGER_TOKEN = "${token}",
+      var DEBUGGER_TOKEN = "${pdtb_token}",
+          REQUEST_ID = "${request_id}",
           CONSOLE_MODE = ${console},
           EVALEX = ${evalex},
           DEBUG_TOOLBAR_STATIC_PATH = "${static_path}",

--- a/pyramid_debugtoolbar/panels/traceback.py
+++ b/pyramid_debugtoolbar/panels/traceback.py
@@ -21,17 +21,17 @@ class TracebackPanel(DebugPanel):
     def __init__(self, request):
         self.request = request
         self.traceback = None
-        self.exc_history = request.exc_history
 
     @property
     def has_content(self):
         return self.traceback is not None
 
     def process_response(self, response):
-        self.traceback = traceback = getattr(self.request, 'pdtb_tb', None)
+        self.traceback = traceback = getattr(
+            self.request.debug_toolbar, 'traceback', None)
         if self.traceback is not None:
             exc = escape(traceback.exception)
-            evalex = self.exc_history.eval_exc
+            evalex = self.request.registry.pdtb_eval_exc
 
             self.data = {
                 'evalex':           evalex and 'true' or 'false',
@@ -42,8 +42,8 @@ class TracebackPanel(DebugPanel):
                 'exception_type':   escape(traceback.exception_type),
                 'plaintext':        traceback.plaintext,
                 'plaintext_cs':     re.sub('-{2,}', '-', traceback.plaintext),
-                'traceback_id':     traceback.id,
-                'token':            self.request.registry.pdtb_token,
+                'pdtb_token':       self.request.registry.pdtb_token,
+                'request_id':       self.request.pdtb_id,
             }
 
         # stop hanging onto the request after the response is processed
@@ -55,7 +55,7 @@ class TracebackPanel(DebugPanel):
             'static_path': request.static_url(STATIC_PATH),
             'root_path': request.route_url(ROOT_ROUTE_NAME),
             'url': request.route_url(
-                EXC_ROUTE_NAME, pdtb_id=vars['traceback_id']),
+                EXC_ROUTE_NAME, request_id=request.pdtb_id),
 
             # render the summary using the toolbar's request object, not
             # the original request that generated the traceback!
@@ -67,49 +67,64 @@ class TracebackPanel(DebugPanel):
 class ExceptionDebugView(object):
     def __init__(self, request):
         self.request = request
-        exc_history = request.exc_history
-        if exc_history is None:
-            raise HTTPBadRequest('No exception history')
-        self.exc_history = exc_history
-        frm = self.request.params.get('frm')
-        if frm is not None:
-            frm = int(frm)
-        self.frame = frm
-        cmd = self.request.params.get('cmd')
-        self.cmd = cmd
-        self.tb = int(self.request.matchdict['pdtb_id'])
+
+    @property
+    def history(self):
+        request_id = self.request.matchdict['request_id']
+        history = self.request.pdtb_history.get(request_id)
+        if history is None:
+            raise HTTPBadRequest('No history found for request.')
+        return history
+
+    @property
+    def traceback(self):
+        tb = getattr(self.history, 'traceback', None)
+        if tb is None:
+            raise HTTPBadRequest('No traceback found for request.')
+        return tb
+
+    @property
+    def frame(self):
+        frame_id = self.request.matchdict['frame_id']
+        for frame in self.traceback.frames:
+            if frame.id == frame_id:
+                return frame
+        raise HTTPBadRequest('Invalid traceback frame.')
 
     @view_config(route_name='debugtoolbar.exception')
     def exception(self):
-        tb = self.exc_history.tracebacks[self.tb]
+        tb = self.traceback
         body = tb.render_full(self.request).encode('utf-8', 'replace')
-        response = Response(body, status=500)
-        return response
+        return Response(body, content_type='text/html', status=500)
 
     @view_config(route_name='debugtoolbar.source')
     def source(self):
-        exc_history = self.exc_history
-        if self.frame is not None:
-            frame = exc_history.frames.get(self.frame)
-            if frame is not None:
-                return Response(frame.render_source(), content_type='text/html')
-        raise HTTPBadRequest()
+        frame = self.frame
+        body = frame.render_source()
+        return Response(body, content_type='text/html')
 
     @view_config(route_name='debugtoolbar.execute')
     def execute(self):
-        if self.request.exc_history.eval_exc:
-            exc_history = self.exc_history
-            if self.frame is not None and self.cmd is not None:
-                frame = exc_history.frames.get(self.frame)
-                if frame is not None:
-                    result = frame.console.eval(self.cmd)
-                    return Response(result, content_type='text/html')
-        raise HTTPBadRequest()
+        if not self.request.registry.parent_registry.pdtb_eval_exc:
+            raise HTTPBadRequest(
+                'Evaluating code in stack frames is not allowed.')
+        frame = self.frame
+        cmd = self.request.params.get('cmd')
+        if cmd is None:
+            raise HTTPBadRequest('Missing command.')
+        body = frame.console.eval(cmd)
+        return Response(body, content_type='text/html')
 
 def includeme(config):
-    config.add_route(EXC_ROUTE_NAME, '/exception/{pdtb_id}')
-    config.add_route('debugtoolbar.source', '/source/{pdtb_id}')
-    config.add_route('debugtoolbar.execute', '/execute/{pdtb_id}')
+    config.add_route(EXC_ROUTE_NAME, '/{request_id}/exception')
+    config.add_route(
+        'debugtoolbar.source',
+        '{request_id}/exception/source/{frame_id}',
+    )
+    config.add_route(
+        'debugtoolbar.execute',
+        '/{request_id}/exception/execute/{frame_id}',
+    )
 
     config.add_debugtoolbar_panel(TracebackPanel)
     config.scan(__name__)

--- a/pyramid_debugtoolbar/static/debugger/debugger.js
+++ b/pyramid_debugtoolbar/static/debugger/debugger.js
@@ -45,17 +45,20 @@ $(function() {
             .click(function() {
               sourceView.slideUp('fast');
             });
-        $.get(window.DEBUG_TOOLBAR_ROOT_PATH + 'source',
-                {frm: frameID, token: window.DEBUGGER_TOKEN}, function(data) {
-          $('table', sourceView)
-            .replaceWith(data);
-          if (!sourceView.is(':visible'))
-            sourceView.slideDown('fast', function() {
+        $.get(
+          window.DEBUG_TOOLBAR_ROOT_PATH + 'source/' + window.TRACEBACK,
+          {frm: frameID},
+          function(data) {
+            $('table', sourceView)
+              .replaceWith(data);
+            if (!sourceView.is(':visible'))
+              sourceView.slideDown('fast', function() {
+                focusSourceBlock();
+              });
+            else
               focusSourceBlock();
-            });
-          else
-            focusSourceBlock();
-        });
+          },
+        );
         return false;
       })
       .prependTo(target);
@@ -96,8 +99,7 @@ $(function() {
       label.val('submitting...');
       $.ajax({
         dataType:     'json',
-        url:          window.DEBUG_TOOLBAR_ROOT_PATH + 'paste',
-        data:         {tb: window.TRACEBACK, token: window.DEBUGGER_TOKEN},
+        url:          window.DEBUG_TOOLBAR_ROOT_PATH + 'paste/' + window.TRACEBACK,
         success:      function(data) {
           $('div.plain span.pastemessage')
             .removeClass('pastemessage')
@@ -132,18 +134,21 @@ $(function() {
     var form = $('<form>&gt;&gt;&gt; </form>')
       .submit(function() {
         var cmd = command.val();
-        $.get(window.DEBUG_TOOLBAR_ROOT_PATH + 'execute', {
-                cmd: cmd, frm: frameID, token:window.DEBUGGER_TOKEN}, function(data) {
-          var tmp = $('<div>').html(data);
-          output.append(tmp);
-          command.focus();
-          consoleNode.scrollTop(command.position().top);
-          var old = history.pop();
-          history.push(cmd);
-          if (typeof old != 'undefined')
-            history.push(old);
-          historyPos = history.length - 1;
-        });
+        $.get(
+          window.DEBUG_TOOLBAR_ROOT_PATH + 'execute/' + window.TRACEBACK,
+          {cmd: cmd, frm: frameID},
+          function(data) {
+            var tmp = $('<div>').html(data);
+            output.append(tmp);
+            command.focus();
+            consoleNode.scrollTop(command.position().top);
+            var old = history.pop();
+            history.push(cmd);
+            if (typeof old != 'undefined')
+              history.push(old);
+            historyPos = history.length - 1;
+          },
+        );
         command.val('');
         return false;
       }).

--- a/pyramid_debugtoolbar/static/debugger/debugger.js
+++ b/pyramid_debugtoolbar/static/debugger/debugger.js
@@ -46,8 +46,7 @@ $(function() {
               sourceView.slideUp('fast');
             });
         $.get(
-          window.DEBUG_TOOLBAR_ROOT_PATH + 'source/' + window.TRACEBACK,
-          {frm: frameID},
+          window.DEBUG_TOOLBAR_ROOT_PATH + window.REQUEST_ID + '/exception/source/' + frameID,
           function(data) {
             $('table', sourceView)
               .replaceWith(data);
@@ -99,7 +98,7 @@ $(function() {
       label.val('submitting...');
       $.ajax({
         dataType:     'json',
-        url:          window.DEBUG_TOOLBAR_ROOT_PATH + 'paste/' + window.TRACEBACK,
+        url:          window.DEBUG_TOOLBAR_ROOT_PATH + window.REQUEST_ID + '/exception/paste',
         success:      function(data) {
           $('div.plain span.pastemessage')
             .removeClass('pastemessage')
@@ -135,8 +134,8 @@ $(function() {
       .submit(function() {
         var cmd = command.val();
         $.get(
-          window.DEBUG_TOOLBAR_ROOT_PATH + 'execute/' + window.TRACEBACK,
-          {cmd: cmd, frm: frameID},
+          window.DEBUG_TOOLBAR_ROOT_PATH + window.REQUEST_ID + '/exception/execute/' + frameID,
+          {cmd: cmd},
           function(data) {
             var tmp = $('<div>').html(data);
             output.append(tmp);

--- a/pyramid_debugtoolbar/tbtools.py
+++ b/pyramid_debugtoolbar/tbtools.py
@@ -43,7 +43,7 @@ except NameError:
     pass
 
 FRAME_HTML = text_('''\
-<div class="frame" id="frame-%(id)d">
+<div class="frame" id="frame-%(id)s">
   <h4>File <cite class="filename">"%(filename)s"</cite>,
       line <em class="line">%(lineno)s</em>,
       in <code class="function">%(function_name)s</code></h4>
@@ -239,9 +239,9 @@ class Traceback(object):
         root_path = request.route_url(ROOT_ROUTE_NAME)
         exc = escape(self.exception)
         summary = self.render_summary(include_title=False, request=request)
-        token = request.registry.parent_registry.pdtb_token,
-        url = request.route_url(EXC_ROUTE_NAME, pdtb_id=self.id)
-        evalex = request.exc_history.eval_exc
+        token = request.registry.parent_registry.pdtb_token
+        url = request.route_url(EXC_ROUTE_NAME, request_id=request.pdtb_id)
+        evalex = request.registry.parent_registry.pdtb_eval_exc
         vars = {
             'evalex':           evalex and 'true' or 'false',
             'console':          'false',
@@ -255,7 +255,8 @@ class Traceback(object):
             'traceback_id':     self.id,
             'static_path':      static_path,
             'root_path':        root_path,
-            'token':            token,
+            'pdtb_token':       token,
+            'request_id':       request.pdtb_id,
             'url':              url,
         }
         return render('pyramid_debugtoolbar:templates/exception.dbtmako',
@@ -277,7 +278,7 @@ class Traceback(object):
     def plaintext(self):
         return text_('\n'.join(self.generate_plaintext_traceback()))
 
-    id = property(lambda x: id(x))
+    id = property(lambda x: str(id(x)))
 
 
 class Frame(object):
@@ -422,4 +423,4 @@ class Frame(object):
     def console(self):
         return Console(self.globals, self.locals)
 
-    id = property(lambda x: id(x))
+    id = property(lambda x: str(id(x)))

--- a/pyramid_debugtoolbar/tbtools.py
+++ b/pyramid_debugtoolbar/tbtools.py
@@ -239,9 +239,8 @@ class Traceback(object):
         root_path = request.route_url(ROOT_ROUTE_NAME)
         exc = escape(self.exception)
         summary = self.render_summary(include_title=False, request=request)
-        token = request.registry.parent_registry.pdtb_token
-        qs = {'tb': str(self.id)}
-        url = request.route_url(EXC_ROUTE_NAME, token=token, _query=qs)
+        token = request.registry.parent_registry.pdtb_token,
+        url = request.route_url(EXC_ROUTE_NAME, pdtb_id=self.id)
         evalex = request.exc_history.eval_exc
         vars = {
             'evalex':           evalex and 'true' or 'false',
@@ -255,8 +254,8 @@ class Traceback(object):
             'plaintext_cs':     re.sub('-{2,}', '-', self.plaintext),
             'traceback_id':     self.id,
             'static_path':      static_path,
-            'token':            token,
             'root_path':        root_path,
+            'token':            token,
             'url':              url,
         }
         return render('pyramid_debugtoolbar:templates/exception.dbtmako',
@@ -305,10 +304,7 @@ class Frame(object):
         self.hide = self.locals.get('__traceback_hide__', False)
         info = self.locals.get('__traceback_info__')
         if info is not None:
-            try:
-                info = unicode(info)
-            except UnicodeError:
-                info = str(info).decode('utf-8', 'replace')
+            info = text_(info, errors='replace')
         self.info = info
 
     def render(self):

--- a/pyramid_debugtoolbar/templates/exception.dbtmako
+++ b/pyramid_debugtoolbar/templates/exception.dbtmako
@@ -8,17 +8,6 @@
     <link rel="stylesheet" type="text/css" href="${static_path}bootstrap/css/bootstrap.min.css">
     <link rel="stylesheet" type="text/css" href="${static_path}toolbar/toolbar.css">
     <link rel="stylesheet" type="text/css" href="${static_path}debugger/debugger.css">
-    <script type="text/javascript">
-      var TRACEBACK = ${str(traceback_id)},
-          DEBUGGER_TOKEN = "${token}",
-          CONSOLE_MODE = ${console},
-          EVALEX = ${evalex},
-          DEBUG_TOOLBAR_STATIC_PATH = "${static_path}",
-          DEBUG_TOOLBAR_ROOT_PATH = "${root_path}";
-    </script>
-    <script src="${static_path}jquery/jquery.min.js"></script>
-    <script src="${static_path}bootstrap/js/bootstrap.min.js"></script>
-    <script src="${static_path}debugger/debugger.js"></script>
   </head>
   <body>
     <div class="debugger">
@@ -92,6 +81,18 @@
        ${plaintext_cs}
 
       -->
+
+    <script type="text/javascript">
+      var DEBUGGER_TOKEN = "${pdtb_token}",
+          REQUEST_ID = "${request_id}",
+          CONSOLE_MODE = ${console},
+          EVALEX = ${evalex},
+          DEBUG_TOOLBAR_STATIC_PATH = "${static_path}",
+          DEBUG_TOOLBAR_ROOT_PATH = "${root_path}";
+    </script>
+    <script src="${static_path}jquery/jquery.min.js"></script>
+    <script src="${static_path}bootstrap/js/bootstrap.min.js"></script>
+    <script src="${static_path}debugger/debugger.js"></script>
 
   </body>
 

--- a/pyramid_debugtoolbar/toolbar.py
+++ b/pyramid_debugtoolbar/toolbar.py
@@ -311,11 +311,8 @@ def toolbar_tween_factory(handler, registry, _logger=None, _dispatch=None):
                         response.status_int = 200
 
             toolbar.process_response(request, response)
-            # Don't store the favicon.ico request
-            # it's requested by the browser automatically
-            if not "/favicon.ico" == request.path:
-                toolbar.response = response
-                request_history.put(request.pdtb_id, toolbar)
+            toolbar.response = response
+            request_history.put(request.pdtb_id, toolbar)
 
             if not show_on_exc_only and response.content_type in html_types:
                 toolbar.inject(request, response)

--- a/pyramid_debugtoolbar/toolbar_app.py
+++ b/pyramid_debugtoolbar/toolbar_app.py
@@ -194,11 +194,15 @@ def sse(request):
         last_request_pair = history.last(1)[0]
         last_request_id = last_request_pair[0]
         if not last_request_id == client_last_request_id:
-            data = [[
-                _id,
-                toolbar.json,
-                'active' if active_request_id == _id else ''
-            ] for _id, toolbar in history.last(max_visible_requests)]
+            data = [
+                [
+                    _id,
+                    toolbar.json,
+                    'active' if active_request_id == _id else ''
+                ]
+                for _id, toolbar in history.last(max_visible_requests)
+                if toolbar.visible
+            ]
             if data:
                 response.text = U_SSE_PAYLOAD.format(last_request_id,
                                                      json.dumps(data))

--- a/pyramid_debugtoolbar/toolbar_app.py
+++ b/pyramid_debugtoolbar/toolbar_app.py
@@ -8,7 +8,6 @@ from pyramid_debugtoolbar.compat import text_
 
 from pyramid_debugtoolbar.toolbar import IPanelMap
 from pyramid_debugtoolbar.utils import (
-    find_request_history,
     get_setting,
     ROOT_ROUTE_NAME,
     SETTINGS_PREFIX,
@@ -44,11 +43,16 @@ def make_toolbar_app(settings, parent_registry):
     config.include('pyramid_mako')
     config.add_mako_renderer('.dbtmako', settings_prefix='dbtmako.')
 
-    config.add_route_predicate('history_request', HistoryRequestRoutePredicate)
-
     config.add_request_method(
-        lambda r: r.registry.parent_registry.exc_history,
-        'exc_history', reify=True)
+        lambda r: r.matchdict.get('request_id'),
+        'pdtb_id',
+        reify=True,
+    )
+    config.add_request_method(
+        lambda r: r.registry.parent_registry.pdtb_history,
+        'pdtb_history',
+        reify=True,
+    )
 
     config.add_static_view('static', STATIC_PATH)
     config.add_route(ROOT_ROUTE_NAME, '/', static=True)
@@ -69,22 +73,6 @@ def make_toolbar_app(settings, parent_registry):
         config.include(include)
 
     return config.make_wsgi_app()
-
-class HistoryRequestRoutePredicate(object):
-    def __init__(self, val, config):
-        assert isinstance(val, bool), 'must be a bool'
-        self.val = val
-
-    def text(self):
-        return 'tbhistory = %s' % self.val
-
-    phash = text
-
-    def __call__(self, info, request):
-        match = info['match']
-        history = find_request_history(request)
-        is_historical = bool(history.get(match.get('request_id')))
-        return not (is_historical ^ self.val)
 
 def add_debugtoolbar_panel(config, panel_class, is_global=False):
     """
@@ -148,7 +136,7 @@ def redirect_view(request):
     renderer='pyramid_debugtoolbar:templates/toolbar.dbtmako'
 )
 def request_view(request):
-    history = find_request_history(request)
+    history = request.pdtb_history
 
     try:
         last_request_pair = history.last(1)[0]
@@ -194,7 +182,7 @@ U_SSE_PAYLOAD = text_("id:{0}\nevent: new_request\ndata:{1}\n\n")
 def sse(request):
     response = request.response
     response.content_type = 'text/event-stream'
-    history = find_request_history(request)
+    history = request.pdtb_history
     response.text = U_BLANK
 
     active_request_id = text_(request.GET.get('request_id'))

--- a/pyramid_debugtoolbar/utils.py
+++ b/pyramid_debugtoolbar/utils.py
@@ -190,9 +190,6 @@ def addr_in(addr, hosts):
 def last_proxy(addr):
     return addr.split(',').pop().strip()
 
-def find_request_history(request):
-    return request.registry.parent_registry.request_history
-
 def debug_toolbar_url(request, *elements, **kw):
     return request.route_url('debugtoolbar', subpath=elements, **kw)
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -58,7 +58,7 @@ class Test_auth(unittest.TestCase):
         resp = self._req('/hello/secrets', remote_user='admin')
         self.assertTrue(resp.html.body.link is not None, 'unexpectedly None')
         # dive into the request history stored by the toolbar tween
-        request_id = self.testapp.app.registry.request_history[0][0]
+        request_id = self.testapp.app.registry.pdtb_history[0][0]
         # check it against the link in the injected html
         self.assertTrue(request_id in resp.html.body.div.div.a['href'])
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -2,6 +2,7 @@ import unittest
 
 from pyramid_debugtoolbar.compat import text_
 from pyramid_debugtoolbar.compat import bytes_
+from pyramid.httpexceptions import HTTPBadRequest
 from pyramid import testing
 
 class TestExceptionDebugView(unittest.TestCase):
@@ -9,6 +10,7 @@ class TestExceptionDebugView(unittest.TestCase):
         self.config = testing.setUp()
         self.config.registry.settings['mako.directories'] = []
         self.config.registry.parent_registry = self.config.registry
+        self.config.registry.parent_registry.pdtb_eval_exc = True
         self.config.registry.pdtb_token = 'token'
         self.config.include('pyramid_mako')
         self.config.add_mako_renderer('.dbtmako', settings_prefix='dbtmako.')
@@ -21,90 +23,70 @@ class TestExceptionDebugView(unittest.TestCase):
         return ExceptionDebugView(request)
 
     def _makeRequest(self):
+        from pyramid_debugtoolbar.utils import ToolbarStorage
         request = testing.DummyRequest()
-        request.secret = 'abc';
-        request.matchdict['token'] = 'token'
-        request.exc_history = self._makeExceptionHistory()
+        request.matchdict['request_id'] = 'reqid'
+        request.matchdict['frame_id'] = '0'
+
+        toolbar = DummyToolbar()
+        toolbar.traceback = self._makeTraceback('tbid')
+
+        history = ToolbarStorage(10)
+        history.put('reqid', toolbar)
+        request.pdtb_history = history
         return request
 
-    def _makeExceptionHistory(self, frames=None):
+    def _makeTraceback(self, tbid, frames=None):
         if frames is None:
-            frm = DummyFrame()
-            frames = {0:frm}
-        exc_history = DummyExceptionHistory(frames)
-        exc_history.eval_exc = True
-        return exc_history
+            frm = DummyFrame('0')
+            frames = [frm]
+        return DummyTraceback(tbid, frames)
 
-    def test_no_exc_history(self):
-        from pyramid.httpexceptions import HTTPBadRequest
+    def test_exception_with_no_traceback(self):
         request = self._makeRequest()
-        request.static_url = lambda *arg, **kw: 'http://static'
-        request.params['frm'] = '0'
-        request.exc_history = None
-        self.assertRaises(HTTPBadRequest, self._makeOne, request)
-
-    def test_without_token_in_request(self):
-        from pyramid.httpexceptions import HTTPBadRequest
-        request = self._makeRequest()
-        del request.matchdict['token']
-        self.assertRaises(HTTPBadRequest, self._makeOne, request)
-    def test_with_bad_token_in_request(self):
-        from pyramid.httpexceptions import HTTPBadRequest
-        request = self._makeRequest()
-        request.matchdict['token'] = 'wrong'
-        self.assertRaises(HTTPBadRequest, self._makeOne, request)
+        del request.pdtb_history.last(1)[0][1].traceback
+        view = self._makeOne(request)
+        self.assertRaises(HTTPBadRequest, view.exception)
 
     def test_source(self):
         request = self._makeRequest()
-        request.params['frm'] = '0'
         view = self._makeOne(request)
         response = view.source()
         self.assertEqual(response.body, bytes_('source'))
         self.assertEqual(response.content_type, 'text/html')
 
-    def test_source_no_frame(self):
-        request = self._makeRequest()
-        view = self._makeOne(request)
-        response = view.source()
-        self.assertEqual(response.status_int, 400)
-
     def test_source_frame_not_found(self):
         request = self._makeRequest()
-        request.params['frm'] = '1'
+        request.matchdict['frame_id'] = 'missing'
         view = self._makeOne(request)
-        response = view.source()
-        self.assertEqual(response.status_int, 400)
+        self.assertRaises(HTTPBadRequest, view.source)
 
     def test_execute(self):
         request = self._makeRequest()
-        request.params['frm'] = '0'
         request.params['cmd'] = 'doit'
         view = self._makeOne(request)
         response = view.execute()
         self.assertEqual(response.body, bytes_('evaled'))
         self.assertEqual(response.content_type, 'text/html')
 
-    def test_execute_frame_is_None(self):
-        request = self._makeRequest()
-        request.params['cmd'] = 'doit'
-        view = self._makeOne(request)
-        response = view.execute()
-        self.assertEqual(response.status_int, 400)
-
     def test_execute_cmd_is_None(self):
         request = self._makeRequest()
-        request.params['frm'] = '0'
         view = self._makeOne(request)
-        response = view.execute()
-        self.assertEqual(response.status_int, 400)
+        self.assertRaises(HTTPBadRequest, view.execute)
 
     def test_execute_nosuchframe(self):
         request = self._makeRequest()
-        request.params['frm'] = '1'
+        request.matchdict['frame_id'] = 'missing'
         request.params['cmd'] = 'doit'
         view = self._makeOne(request)
-        response = view.execute()
-        self.assertEqual(response.status_int, 400)
+        self.assertRaises(HTTPBadRequest, view.execute)
+
+    def test_execute_disabled(self):
+        request = self._makeRequest()
+        request.registry.parent_registry.pdtb_eval_exc = False
+        request.params['cmd'] = 'doit'
+        view = self._makeOne(request)
+        self.assertRaises(HTTPBadRequest, view.execute)
 
     def test_exception_summary(self):
         from pyramid.renderers import render
@@ -125,10 +107,12 @@ class TestExceptionDebugView(unittest.TestCase):
         self.assertTrue(
             text_('<pre>Frame1</pre><pre>Frame2</pre>') in html, html)
 
+class DummyToolbar(object):
+    pass
 
-class DummyExceptionHistory(object):
-    def __init__(self, frames):
-        self.token = 'token'
+class DummyTraceback(object):
+    def __init__(self, id, frames):
+        self.id = id
         self.frames = frames
 
 class DummyConsole(object):
@@ -136,8 +120,9 @@ class DummyConsole(object):
         return 'evaled'
 
 class DummyFrame(object):
-    def __init__(self):
+    def __init__(self, id):
         self.console = DummyConsole()
+        self.id = id
 
     def render_source(self):
         return 'source'


### PR DESCRIPTION
So this turned into a bit of a rabbit hole cleaning up a lot of cruft in the toolbar with regard to exceptions.

1. Tracebacks are now tied to the per-request toolbar object one-to-one. A request may have one traceback. Previously they actually stuck around for the entire lifetime of the app instead of being collected by the `max_request_history` setting.

2. The routes for exceptions are standardized to look similar to the SQLA ajax routes. For example, `/{request_id}/exception` instead of `/exception?token=...&tb=...` and `/{request_id}/exception/execute/{frame_id}?cmd=...` instead of `/exception?token=...&tb=...&frm=...&cmd=...`.

3. Fixed the url generation for the traceback panel link at the bottom of the traceback... it was actually empty previously - it got lost somewhere along the way.

4. `/favicon.ico` is no longer specially handled.. it's just part of `exclude_prefixes` like anything else that you want to exclude.

5. `request.pdtb_history` is available for toolbar requests (mostly ajax requests or panel rendering).

6. Removed the unused history predicate.

7. URL generation was broken in the `debugger.js` but that's fixed now so the execute/source buttons work in tracebacks.