### PR TITLE
squashed exceptions would cause a bug when logging the output

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,9 @@
+unreleased
+----------
+
+- Fix a bug with the logging of squashed exceptions on Python < 3.5.
+  See https://github.com/Pylons/pyramid_debugtoolbar/pull/320
+
 4.2 (2017-06-21)
 ----------------
 

--- a/demo/demo.py
+++ b/demo/demo.py
@@ -49,7 +49,7 @@ def squashed_exc(request):
     context=RuntimeError,
     renderer='notfound.mako',
 )
-def notfound_view(request):
+def squashed_exc_error_view(request):
     request.response.status_code = 404
     return {}
 

--- a/pyramid_debugtoolbar/toolbar.py
+++ b/pyramid_debugtoolbar/toolbar.py
@@ -252,7 +252,7 @@ def toolbar_tween_factory(handler, registry, _logger=None, _dispatch=None):
                 subrequest = make_subrequest(
                     request, root_path, request.pdtb_id + '/exception')
                 exc_msg = msg % (request.url, subrequest.url)
-                _logger.exception(exc_msg, exc_info=request.exc_info)
+                _logger.error(exc_msg, exc_info=request.exc_info)
 
         except Exception:
             if intercept_exc:


### PR DESCRIPTION
On python < 3.5 `logger.exception` would force the `exc_info` parameter to `1` or `True` (depending on the version). In 3.5 it was switched to a default kwarg that could be overridden. This fix uses `log.error` instead which does not force the value of `exc_info` on any version of Python.

fixes #319