### PR TITLE
javascript fixes for jshint/etc

### DIFF
--- a/src/pyramid_debugtoolbar/static/debugger/debugger.js
+++ b/src/pyramid_debugtoolbar/static/debugger/debugger.js
@@ -21,8 +21,7 @@ $(function() {
       * Add an interactive console to the frames
       */
     if (EVALEX)
-      $('<img class="console-icon" src="'
-        + window.DEBUG_TOOLBAR_STATIC_PATH + 'debugger/img/console.png">')
+      $('<img class="console-icon" src="' + window.DEBUG_TOOLBAR_STATIC_PATH + 'debugger/img/console.png">')
         .attr('title', 'Open an interactive python shell in this frame')
         .click(function() {
           consoleNode = openShell(consoleNode, target, frameID);
@@ -56,7 +55,7 @@ $(function() {
               });
             else
               focusSourceBlock();
-          },
+          }
         );
         return false;
       })
@@ -126,7 +125,7 @@ $(function() {
       return consoleNode.slideToggle('fast');
     consoleNode = $('<pre class="console">')
       .appendTo(target.parent())
-      .hide()
+      .hide();
     var historyPos = 0, history = [''];
     var output = $('<div class="output">[console ready]</div>')
       .appendTo(consoleNode);
@@ -146,7 +145,7 @@ $(function() {
             if (typeof old != 'undefined')
               history.push(old);
             historyPos = history.length - 1;
-          },
+          }
         );
         command.val('');
         return false;
@@ -183,7 +182,7 @@ $(function() {
     for (var i = 0; i < 7; i++) {
       tmp = line.prev();
       if (!(tmp && tmp.is('.in-frame')))
-        break
+        break;
       line = tmp;
     }
     var container = $('div.sourceview');

--- a/src/pyramid_debugtoolbar/static/toolbar/toolbar.js
+++ b/src/pyramid_debugtoolbar/static/toolbar/toolbar.js
@@ -63,7 +63,7 @@ $(function() {
     headerTemplate: '{content} {icon}'
   });
 
-  bootstrap_panels = ['pDebugVersionPanel', 'pDebugHeaderPanel']
+  bootstrap_panels = ['pDebugVersionPanel', 'pDebugHeaderPanel'];
 
   for (var i = 0; i < bootstrap_panels.length; i++) {
     $('.pDebugWindow #' + bootstrap_panels[i] + '-content').show();
@@ -74,7 +74,7 @@ $(function() {
 $(function () {
   var source;
   function new_request(e) {
-    $('ul#requests li a').tooltip('hide')
+    $('ul#requests li a').tooltip('hide');
     var html = '<li><h4>Requests</strong></h4></li>';
     var requests = $('ul#requests');
     var data = JSON.parse(e.data);
@@ -189,9 +189,9 @@ $(function() {
 			return displayable;
 		}
 		var selected_panel_text = panel_tab_element.attr('id');
-		displayable["panel_tab_element"] = panel_tab_element
-		displayable["selected_panel_text"] = selected_panel_text
-		return displayable
+		displayable.panel_tab_element = panel_tab_element;
+		displayable.selected_panel_text = selected_panel_text;
+		return displayable;
 	}
 	function handle_alt_panel(do_cookie){
 		// consolidates finding and showing an alternate panel
@@ -203,7 +203,7 @@ $(function() {
 		if (displayable.panel_tab_element && displayable.selected_panel_text) {
 			show_panel(displayable.panel_tab_element, displayable.selected_panel_text);
 			if (do_cookie){
-				$.cookie(COOKIE_NAME_STICKYPANEL_SELECTED, selected_panel_text);
+				$.cookie(COOKIE_NAME_STICKYPANEL_SELECTED, displayable.selected_panel_text);
 			}
 		}
 	}


### PR DESCRIPTION
it looks like the 4.2/4.3 branches rewrote some debugger.js functionality that is not universally compatible with all browsers. the trailing commas in a few places can completely break the debugger in some browsers; the lack of semicolons in some other places might cause issues as well.

this is just a light edit for full compatibility against the jshint defaults (http://jshint.com/, http://jshint.com/install/)

this doesn't comply with the stricter tool jslint (http://jslint.com/, https://github.com/douglascrockford/JSLint)

this PR integrates PR #325 to fix a similar issue in some browsers as well.