### PR TITLE
exceptions: allow a way to supress squashed exceptions logging

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -122,3 +122,4 @@ Contributors
 - Dan Clark, 2017-05-22
 - Jens Carl, 2017-05-22
 - Andrey Tretyakov, 2017-05-27
+- Marcin Lulek, 2018-02-19

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -279,6 +279,21 @@ logs.
   caching-related response headers will be set by the Pyramid ``http_cache``
   view configuration feature when this is ``true``.
 
+Disable squashed exception information
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can control the level of printed exceptions from `pyramid_debugtoolbar` by
+adding a custom logger configuration.
+
+::
+
+    [loggers]
+    keys = root, debugtoolbar
+
+    [logger_debugtoolar]
+    level = WARN
+    qualname = pyramid_debugtoolbar
+
 
 Custom authorization
 ~~~~~~~~~~~~~~~~~~~~

--- a/src/pyramid_debugtoolbar/toolbar.py
+++ b/src/pyramid_debugtoolbar/toolbar.py
@@ -254,7 +254,7 @@ def toolbar_tween_factory(handler, registry, _logger=None, _dispatch=None):
                 subrequest = make_subrequest(
                     request, root_path, request.pdtb_id + '/exception')
                 exc_msg = msg % (request.url, subrequest.url)
-                _logger.error(exc_msg, exc_info=request.exc_info)
+                _logger.info(exc_msg, exc_info=request.exc_info)
 
         except Exception:
             if intercept_exc:


### PR DESCRIPTION
When migrating from pylons to pyramid the log output was way too noisy because of squashed exception information, this allows us to control if we want to see the information at all.