### PR TITLE
show some post-data if possible

### DIFF
--- a/src/pyramid_debugtoolbar/panels/request_vars.py
+++ b/src/pyramid_debugtoolbar/panels/request_vars.py
@@ -104,9 +104,12 @@ class RequestVarsDebugPanel(DebugPanel):
                 lambda v: self.process_lazy_attr(attr_, is_dict, v),
             )
 
+        post_items = [(k, saferepr(v)) for k, v in request.POST.items()]
+        post_raw = request.body[:4096] if not post_items else None
         data.update({
             'get': [(k, request.GET.getall(k)) for k in request.GET],
-            'post': [(k, saferepr(v)) for k, v in request.POST.items()],
+            'post': post_items,
+            'post_raw': post_raw,
             'cookies': [(k, request.cookies.get(k)) for k in request.cookies],
             'environ': dictrepr(request.environ),
             'extracted_attributes': {},

--- a/src/pyramid_debugtoolbar/panels/templates/request_vars.dbtmako
+++ b/src/pyramid_debugtoolbar/panels/templates/request_vars.dbtmako
@@ -84,7 +84,11 @@
 			</tbody>
 		</table>
 	% else:
-		<p>No POST data</p>
+		<p>No POST variables</p>
+		% if post_raw:
+			<h4>POST Raw Data</h4>
+			<pre>${post_raw}</pre>
+		% endif
 	% endif
 	<hr/>
 </%def>

--- a/src/pyramid_debugtoolbar/panels/templates/request_vars.dbtmako
+++ b/src/pyramid_debugtoolbar/panels/templates/request_vars.dbtmako
@@ -85,9 +85,26 @@
 		</table>
 	% else:
 		<p>No POST variables</p>
-		% if post_raw:
-			<h4>POST Raw Data</h4>
-			<pre>${post_raw}</pre>
+		% if post_details:
+			<h4>POST Data</h4>
+			<table class="table table-striped table-condensed">
+				<tbody>
+					<tr>
+						<th>size</th>
+						<td><code>${post_details['size']}</td>
+					</tr>
+					<tr>
+						<th>preview? (first 4096 chars)</th>
+						<td>
+							% if post_details['preview']:
+								${post_details['preview']}
+							% else:
+								<em>The posted content is not able to be previewed.</em>
+							% endif
+						</td>
+					</tr>
+				</tbody>
+			</table>
 		% endif
 	% endif
 	<hr/>


### PR DESCRIPTION
I went a bit crazy trying to debug a LetsEncrypt client with a fake-endpoint I put together via Pyramid.

The problem was in two parts:

1. the `acme` spec doesn't POST with KV pairs, but with the encoded payload as the entire body.
2. the debugtoolbar sows "No POST Data" when it means "No POST Variables".  Only parsed k/v pairs are consulted.

This suggestion simply populates `post_raw` with the first 4096 chars of the post data *as a fallback* if there are no k/v pairs present.  I limited it to 4096, so a file upload doesn't takeover the screen.

The result is "No Post Data" is now replaced with the data which was actually posted.