### PR TITLE
added engine display to sqlalchemy toolbar

### DIFF
--- a/src/pyramid_debugtoolbar/panels/sqla.py
+++ b/src/pyramid_debugtoolbar/panels/sqla.py
@@ -109,6 +109,7 @@ class SQLADebugPanel(DebugPanel):
         self.data = {
             'queries': data,
             'text': text_,
+            'engines': self.engines,
         }
 
     def render_content(self, request):

--- a/src/pyramid_debugtoolbar/panels/templates/sqlalchemy.dbtmako
+++ b/src/pyramid_debugtoolbar/panels/templates/sqlalchemy.dbtmako
@@ -45,7 +45,7 @@
 		<tr>
 			% if show_engines:
 				<td>
-					<a title="${engine_id_2_url[query['engine_id']]}">${query['engine_id']}</a>
+					<a title="${engine_id_2_url.get(query['engine_id'], '')}">${query['engine_id']}</a>
 				</td>
 			% endif
 			<td>${'%.2f' % query['duration']}</td>

--- a/src/pyramid_debugtoolbar/panels/templates/sqlalchemy.dbtmako
+++ b/src/pyramid_debugtoolbar/panels/templates/sqlalchemy.dbtmako
@@ -1,6 +1,39 @@
+<%
+	engines_seen = set([query['engine_id'] for query in queries])
+	show_engines = True if len(engines_seen) >= 2 else False
+	engine_id_2_url = {}
+%>
+
+
+% if show_engines:
+	<h3>This Request used multiple SqlAlchemy Engines</h3>
+	<table class="table table-striped table-condensed">
+		% for engine_id in engines:
+			<%
+				## try to deref the weakref
+				engine = engines[engine_id]()
+				engine_url = engine.url if engine else None
+				engine_id_2_url[engine_id] = engine_url  # this will be used for mouseovers
+			%>
+			<tr>
+				<th>${engine_id}</th>
+				<td>
+					% if engine:
+						${engine_url}
+					% endif
+				</td>
+			</tr>
+		% endfor
+	</table>
+% endif
+
+
 <table id="pSqlaTable" class="pDebugSortable table table-striped">
 	<thead>
 		<tr>
+			% if show_engines:
+				<th>Engine</th>
+			% endif
 			<th>Time&nbsp;(ms)</th>
 			<th>Action</th>
 			<th>Query</th>
@@ -10,6 +43,11 @@
 	<tbody>
 	% for i, query in enumerate(queries):
 		<tr>
+			% if show_engines:
+				<td>
+					<a title="${engine_id_2_url[query['engine_id']]}">${query['engine_id']}</a>
+				</td>
+			% endif
 			<td>${'%.2f' % query['duration']}</td>
 			<td>
 			% if query['is_select']:


### PR DESCRIPTION
This solves my suggestion to track the sqlalchemy connection in #333.  The information was already tracked, it just was not displayed.

This PR does 2 things:

1. The already-collected `engine` data is injected into the template.
2. The template does an initial loop of the queries to see if multiple engines were used. If so, a new overview table is shown AND a column on the existing table is added with the engine id. The engine's connection string is used as a title element, so a mouse-over will quickly show it.

![sqlalchemy panel update pr](https://user-images.githubusercontent.com/204779/41000154-15e02782-68db-11e8-8297-64987dbfe2f7.png)
