### PR TITLE
Remove parsing of REMOTE_ADDR when it contains a comma

### DIFF
--- a/src/pyramid_debugtoolbar/utils.py
+++ b/src/pyramid_debugtoolbar/utils.py
@@ -202,10 +202,6 @@ def addr_in(addr, hosts):
     return False
 
 
-def last_proxy(addr):
-    return addr.split(',').pop().strip()
-
-
 def debug_toolbar_url(request, *elements, **kw):
     return request.route_url('debugtoolbar', subpath=elements, **kw)
 

--- a/tests/test_toolbar.py
+++ b/tests/test_toolbar.py
@@ -1,8 +1,10 @@
+import warnings
 import unittest
-from webtest import TestApp
+
 from pyramid.request import Request
 from pyramid.response import Response
 from pyramid import testing
+from webtest import TestApp
 
 from pyramid_debugtoolbar.compat import bytes_
 
@@ -419,7 +421,15 @@ class Test_toolbar_handler(unittest.TestCase):
     def test_it_remote_addr_proxies_list(self):
         request = Request.blank('/')
         request.remote_addr = '172.16.63.156, 64.119.211.105'
-        result = self._callFUT(request)
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            # test
+            self._callFUT(request)
+
+            self.assertEqual(len(w), 1)
+            assert "REMOTE_ADDR" in str(w[-1].message)
 
 
 class TestIntegration(unittest.TestCase):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -100,15 +100,3 @@ class Test_addr_in(unittest.TestCase):
 
     def test_in_network_ipv6_interface(self):
         self.assertTrue(self._callFUT('fe80::e556:2a1a:91e2:7023%15', ['::/0']))
-
-
-class Test_last_proxy(unittest.TestCase):
-    def _callFUT(self, addr):
-        from pyramid_debugtoolbar.utils import last_proxy
-        return last_proxy(addr)
-
-    def test_single_host(self):
-        self.assertEqual(self._callFUT('192.168.1.2'), '192.168.1.2')
-
-    def test_multiple_hosts(self):
-        self.assertEqual(self._callFUT('192.168.1.1, 192.168.1.2'), '192.168.1.2')


### PR DESCRIPTION
Some middleware box, not identified in issue #85 is inserting additional
IP addresses for the proxies in the REMOTE_ADDR environ variable.

That's not what it is for, it is supposed to provide the IP address of
the client that made the original request, and then X-Forwarded-For
contains additional information.

However middleware boxes being the type of quality they usually are, we
can't rely on them always placing the proxy IP address first, followed
by the client IP address last.

Especially since X-Forwarded-For is specified as <client>, <proxy 1>,
<proxy 2> and thus is the reverse of whateve this mess is.

So instead we bail out. If you own such a middleware box that sets
REMOTE_ADDR this way, please, for all that is good, please let me know
what it is and who authored it.

Your final WSGI server should parse X-Forwarded-For/Forwarded (if
received from a trusted proxy) and place the client IP in REMOTE_ADDR.

It should then also pass on the X-Forwarded-For/Forwarded header to the
application, as normal.