### PR TITLE
[doc/fix] SampleDebugPanel.title/nav_title are properties

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -581,9 +581,11 @@ sample panel:
        def __init__(self, request):
            self.data = { 'request_path' : request.path_info }
 
+       @property
        def nav_title(self):
            return _('Sample')
 
+       @property
        def title(self):
            return _('Sample')
 


### PR DESCRIPTION
Hello,

As confirmed on IRC those 2 functions should actually be properties.

Kind regards,