### PR TITLE
Handle ValueError in SQLAlchemy debug panel

### DIFF
--- a/src/pyramid_debugtoolbar/panels/sqla.py
+++ b/src/pyramid_debugtoolbar/panels/sqla.py
@@ -92,7 +92,7 @@ class SQLADebugPanel(DebugPanel):
             except TypeError:
                 pass  # object not JSON serializable
             except ValueError:
-                pass  # JSON cyclic can errors generate ValueError exceptions
+                pass  # JSON parameters serialization can generate ValueError exceptions
             except UnicodeDecodeError:
                 pass  # parameters contain non-utf8 (probably binary) data
 

--- a/src/pyramid_debugtoolbar/panels/sqla.py
+++ b/src/pyramid_debugtoolbar/panels/sqla.py
@@ -91,6 +91,8 @@ class SQLADebugPanel(DebugPanel):
                 params = url_quote(json.dumps(query['parameters']))
             except TypeError:
                 pass  # object not JSON serializable
+            except ValueError:
+                pass  # JSON cyclic can errors generate ValueError exceptions
             except UnicodeDecodeError:
                 pass  # parameters contain non-utf8 (probably binary) data
 


### PR DESCRIPTION
I use GeoAlchemy which can use JSON parameters.
Serializing these parameters can generate ValueError, which are not handled in SQLA debug panel...