### PR TITLE
Inject closing slash character if content_type of response is xhtml 

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -124,3 +124,4 @@ Contributors
 - Andrey Tretyakov, 2017-05-27
 - Marcin Lulek, 2018-02-19
 - Wim De Clercq, 2018-11-23
+- Holger Peters, 2020-02-06

--- a/src/pyramid_debugtoolbar/toolbar.py
+++ b/src/pyramid_debugtoolbar/toolbar.py
@@ -105,23 +105,30 @@ class DebugToolbar(object):
         """
         Inject the debug toolbar iframe into an HTML response.
         """
-        # called in host app
-        response_html = response.body
-        toolbar_url = debug_toolbar_url(request, request.pdtb_id)
-        button_style = get_setting(request.registry.settings,
-                                   'button_style', '')
-        css_path = request.static_url(
-            STATIC_PATH + 'toolbar/toolbar_button.css')
-        toolbar_html = toolbar_html_template % {
-            'button_style': (
-                'style="{0}"'.format(button_style) if button_style else ""),
-            'css_path': css_path,
-            'toolbar_url': toolbar_url}
+        is_xhtml = "xhtml" in response.content_type
+
+        toolbar_html = toolbar_html_template.format(
+            button_style=self._button_style(request),
+            css_path=self._css_path(request),
+            toolbar_url=debug_toolbar_url(request, request.pdtb_id),
+            optional_slash=("/" if is_xhtml else ""))
+
         toolbar_html = toolbar_html.encode(response.charset or 'utf-8')
         response.body = replace_insensitive(
-            response_html, bytes_('</body>'),
+            response.body, bytes_('</body>'),
             toolbar_html + bytes_('</body>')
         )
+
+    def _css_path(self, request):
+        return request.static_url(STATIC_PATH + 'toolbar/toolbar_button.css')
+
+    def _button_style(self, request):
+        button_style = get_setting(request.registry.settings,
+                                   'button_style', '')
+        if button_style:
+            return 'style="{0}"'.format(button_style)
+        else:
+            return ''
 
 
 def process_traceback(info):
@@ -336,12 +343,12 @@ def toolbar_tween_factory(handler, registry, _logger=None, _dispatch=None):
 
 
 toolbar_html_template = """\
-<link rel="stylesheet" type="text/css" href="%(css_path)s">
+<link rel="stylesheet" type="text/css" href="{css_path}" {optional_slash}>
 
 <div id="pDebug">
-    <div %(button_style)s id="pDebugToolbarHandle">
+    <div {button_style} id="pDebugToolbarHandle">
         <a title="Show Toolbar" id="pShowToolBarButton"
-           href="%(toolbar_url)s" target="pDebugToolbar">&#171;</a>
+           href="{toolbar_url}" target="pDebugToolbar">&#171;</a>
     </div>
 </div>
 """

--- a/src/pyramid_debugtoolbar/toolbar.py
+++ b/src/pyramid_debugtoolbar/toolbar.py
@@ -336,7 +336,7 @@ def toolbar_tween_factory(handler, registry, _logger=None, _dispatch=None):
 
 
 toolbar_html_template = """\
-<link rel="stylesheet" type="text/css" href="%(css_path)s">
+<link rel="stylesheet" type="text/css" href="%(css_path)s" />
 
 <div id="pDebug">
     <div %(button_style)s id="pDebugToolbarHandle">


### PR DESCRIPTION
Issue #359

I took the liberty to change the template's string to use the `format` method as I found other usages of `format` so I think its within the Python versions you support.

Still need to test this.