### PR TITLE
docs: Fix simple typo, intially -> initially

### DIFF
--- a/src/pyramid_debugtoolbar/static/jquery.tablesorter/js/jquery.tablesorter.widgets.min.js
+++ b/src/pyramid_debugtoolbar/static/jquery.tablesorter/js/jquery.tablesorter.widgets.min.js
@@ -193,7 +193,7 @@ b.buildSelect(f.table,l,"",!0,k.hasClass(g.filter_onlyAvail))}
 b.buildDefault(e,!0),b.bindSearch(e,f.$table.find("."+d.filter),!0),g.filter_external&&b.bindSearch(e,g.filter_external),g.filter_hideFilters&&b.hideFilters(f),
 // show processing icon
 f.showProcessing&&(j="filterStart filterEnd ".split(" ").join(f.namespace+"filter "),f.$table.unbind(j.replace(c.regex.spaces," ")).bind(j,function(b,g){k=g?f.$table.find("."+d.header).filter("[data-column]").filter(function(){return""!==g[a(this).data("column")]}):"",c.isProcessing(e,"filterStart"===b.type,g?k:"")})),
-// set filtered rows count ( intially unfiltered )
+// set filtered rows count ( initially unfiltered )
 f.filteredRows=f.totalRows,j="tablesorter-initialized pagerBeforeInitialized ".split(" ").join(f.namespace+"filter "),f.$table.unbind(j.replace(c.regex.spaces," ")).bind(j,function(){var a=this.config.widgetOptions;m=b.setDefaults(e,f,a)||[],m.length&&(f.delayInit&&""===m.join("")||c.setFilters(e,m,!0)),f.$table.trigger("filterFomatterUpdate"),setTimeout(function(){a.filter_initialized||b.filterInitComplete(f)},100)}),f.pager&&f.pager.initialized&&!g.filter_initialized&&(f.$table.trigger("filterFomatterUpdate"),setTimeout(function(){b.filterInitComplete(f)},100))},
 // $cell parameter, but not the config, is passed to the filter_formatters,
 // so we have to work with it instead


### PR DESCRIPTION
There is a small typo in src/pyramid_debugtoolbar/static/jquery.tablesorter/js/jquery.tablesorter.widgets.min.js.

Should read `initially` rather than `intially`.

