### PR TITLE
SQLAlchemy Panel - log transactional events

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -50,6 +50,7 @@ testing =
     WebTest
     nose
     coverage
+    sqlalchemy
 docs =
     Sphinx >= 1.7.5
     pylons-sphinx-themes >= 0.3

--- a/src/pyramid_debugtoolbar/panels/sqla.py
+++ b/src/pyramid_debugtoolbar/panels/sqla.py
@@ -45,7 +45,79 @@ try:
                 )
         delattr(conn, 'pdtb_start_timer')
 
+    def _transactional_event_logger(conn, stmt, context=''):
+        """
+        Abstract logger for transactional events
+
+        """
+        request = get_current_request()
+        if request is not None and hasattr(request, 'pdtb_sqla_queries'):
+            with lock:
+                engines = request.registry.pdtb_sqla_engines
+                engines[id(conn.engine)] = weakref.ref(conn.engine)
+                queries = request.pdtb_sqla_queries
+                queries.append(
+                    {
+                        'engine_id': id(conn.engine),
+                        'duration': 0,
+                        'statement': stmt,
+                        'parameters': '',
+                        'context': '',
+                    }
+                )
+
+    @event.listens_for(Engine, "begin")
+    def _begin(conn):
+        stmt = 'begin;'
+        _transactional_event_logger(conn, stmt)
+
+    @event.listens_for(Engine, "commit")
+    def _commit(conn):
+        stmt = 'commit;'
+        _transactional_event_logger(conn, stmt)
+
+    @event.listens_for(Engine, "rollback")
+    def _rollback(conn):
+        stmt = 'rollback;'
+        _transactional_event_logger(conn, stmt)
+
+    @event.listens_for(Engine, "savepoint")
+    def _savepoint(conn, name):
+        stmt = 'savepoint %s;' % name
+        _transactional_event_logger(conn, stmt)
+
+    @event.listens_for(Engine, "rollback_savepoint")
+    def _rollback_savepoint(conn, name, context):
+        stmt = 'rollback_savepoint %s;' % name
+        _transactional_event_logger(conn, stmt, context)
+
+    @event.listens_for(Engine, "release_savepoint")
+    def _release_savepoint(conn, name, context):
+        stmt = 'release_savepoint %s;' % name
+        _transactional_event_logger(conn, stmt, context)
+
+    @event.listens_for(Engine, "begin_twophase")
+    def _begin_twophase(conn, xid):
+        stmt = 'begin_twophase %s;' % xid
+        _transactional_event_logger(conn, stmt)
+
+    @event.listens_for(Engine, "prepare_twophase")
+    def _prepare_twophase(conn, xid):
+        stmt = 'prepare_twophase %s;' % xid
+        _transactional_event_logger(conn, stmt)
+
+    @event.listens_for(Engine, "commit_twophase")
+    def _commit_twophase(conn, xid, is_prepared):
+        stmt = 'commit_twophase %s %s;' % (xid, is_prepared)
+        _transactional_event_logger(conn, stmt)
+
+    @event.listens_for(Engine, "rollback_twophase")
+    def _rollback_twophase(conn, xid, is_prepared):
+        stmt = 'rollback_twophase %s %s;' % (xid, is_prepared)
+        _transactional_event_logger(conn, stmt)
+
     has_sqla = True
+
 except ImportError:
     has_sqla = False
 

--- a/src/pyramid_debugtoolbar/panels/sqla.py
+++ b/src/pyramid_debugtoolbar/panels/sqla.py
@@ -68,52 +68,52 @@ try:
 
     @event.listens_for(Engine, "begin")
     def _begin(conn):
-        stmt = 'begin;'
+        stmt = '-- [event.begin]'
         _transactional_event_logger(conn, stmt)
 
     @event.listens_for(Engine, "commit")
     def _commit(conn):
-        stmt = 'commit;'
+        stmt = '-- [event.commit]'
         _transactional_event_logger(conn, stmt)
 
     @event.listens_for(Engine, "rollback")
     def _rollback(conn):
-        stmt = 'rollback;'
+        stmt = '-- [event.rollback]'
         _transactional_event_logger(conn, stmt)
 
     @event.listens_for(Engine, "savepoint")
     def _savepoint(conn, name):
-        stmt = 'savepoint %s;' % name
+        stmt = '-- [event.savepoint %s]' % name
         _transactional_event_logger(conn, stmt)
 
     @event.listens_for(Engine, "rollback_savepoint")
     def _rollback_savepoint(conn, name, context):
-        stmt = 'rollback_savepoint %s;' % name
+        stmt = '-- [event.rollback_savepoint %s]' % name
         _transactional_event_logger(conn, stmt, context)
 
     @event.listens_for(Engine, "release_savepoint")
     def _release_savepoint(conn, name, context):
-        stmt = 'release_savepoint %s;' % name
+        stmt = '-- [event.release_savepoint %s]' % name
         _transactional_event_logger(conn, stmt, context)
 
     @event.listens_for(Engine, "begin_twophase")
     def _begin_twophase(conn, xid):
-        stmt = 'begin_twophase %s;' % xid
+        stmt = '-- [event.begin_twophase %s]' % xid
         _transactional_event_logger(conn, stmt)
 
     @event.listens_for(Engine, "prepare_twophase")
     def _prepare_twophase(conn, xid):
-        stmt = 'prepare_twophase %s;' % xid
+        stmt = '-- [event.prepare_twophase %s]' % xid
         _transactional_event_logger(conn, stmt)
 
     @event.listens_for(Engine, "commit_twophase")
     def _commit_twophase(conn, xid, is_prepared):
-        stmt = 'commit_twophase %s %s;' % (xid, is_prepared)
+        stmt = '-- [event.commit_twophase %s %s]' % (xid, is_prepared)
         _transactional_event_logger(conn, stmt)
 
     @event.listens_for(Engine, "rollback_twophase")
     def _rollback_twophase(conn, xid, is_prepared):
-        stmt = 'rollback_twophase %s %s;' % (xid, is_prepared)
+        stmt = '-- [event.rollback_twophase %s %s]' % (xid, is_prepared)
         _transactional_event_logger(conn, stmt)
 
     has_sqla = True

--- a/tests/test_panels/_utils.py
+++ b/tests/test_panels/_utils.py
@@ -10,6 +10,13 @@ re_toolbar_link = re.compile(
 )
 
 
+def ok_response_factory():
+    return Response(
+        "<html><head></head><body>OK</body></html>",
+        content_type="text/html",
+    )
+
+
 class _TestDebugtoolbarPanel(unittest.TestCase):
     def setUp(self):
         self.re_toolbar_link = re_toolbar_link
@@ -19,10 +26,7 @@ class _TestDebugtoolbarPanel(unittest.TestCase):
 
         # create a view
         def empty_view(request):
-            return Response(
-                "<html><head></head><body>OK</body></html>",
-                content_type="text/html",
-            )
+            return ok_response_factory()
 
         config.add_view(empty_view)
         self.app = self.config.make_wsgi_app()

--- a/tests/test_panels/test_sqla.py
+++ b/tests/test_panels/test_sqla.py
@@ -1,0 +1,267 @@
+from pyramid import testing
+from pyramid.request import Request
+import sqlalchemy
+from sqlalchemy.sql import text as sqla_text
+import sys
+
+from pyramid_debugtoolbar.compat import PY3
+
+from ._utils import (
+    _TestDebugtoolbarPanel,
+    ok_response_factory,
+    re_toolbar_link,
+)
+
+
+class _TestSQLAlchemyPanel(_TestDebugtoolbarPanel):
+    """
+    Base class for testing SQLAlchemy panel
+    """
+
+    config = None
+    app = None
+
+    def _sqlalchemy_view(self, context, request):
+        """
+        This function should define a Pyramid view
+        * (potentially) invoke SQLAlchemy
+        * return a Response
+        """
+        raise NotImplementedError()
+
+    def setUp(self):
+        self.config = config = testing.setUp()
+        config.include("pyramid_debugtoolbar")
+        config.add_view(self._sqlalchemy_view)
+        self.app = config.make_wsgi_app()
+
+    def tearDown(self):
+        testing.tearDown()
+
+    def _makeOne(self):
+        """
+        Makes a request to the main App
+        * which invokes `self._sqlalchemy_view`
+        * Make a request to the toolbar
+        * return the toolbar Response
+        """
+        # make the app
+        app = self.config.make_wsgi_app()
+        # make a request
+        req1 = Request.blank("/")
+        req1.remote_addr = "127.0.0.1"
+        resp1 = req1.get_response(app)
+        self.assertEqual(resp1.status_code, 200)
+        self.assertIn("http://localhost/_debug_toolbar/", resp1.text)
+
+        # check the toolbar
+        links = re_toolbar_link.findall(resp1.text)
+        self.assertIsNotNone(links)
+        self.assertIsInstance(links, list)
+        self.assertEqual(len(links), 1)
+        toolbar_link = links[0]
+
+        req2 = Request.blank(toolbar_link)
+        req2.remote_addr = "127.0.0.1"
+        resp2 = req2.get_response(app)
+
+        return resp2
+
+    def _check_rendered__panel(self, resp):
+        """
+        Ensure the rendered panel exists with statements
+        """
+        self.assertIn('<li class="" id="pDebugPanel-sqlalchemy">', resp.text)
+        self.assertIn(
+            '<div id="pDebugPanel-sqlalchemy-content" class="panelContent" '
+            'style="display: none;">',
+            resp.text,
+        )
+
+    def _check_rendered__select_null(self, resp):
+        """
+        Ensure the rendered panel has the "SELECT NULL" statement rendered
+
+        Note: the <pre> styles are different on the Py2 and Py3 libraries
+        """
+        self.assertIn(
+            '<span style="color: #008800; font-weight: bold">SELECT</span> '
+            '<span style="color: #008800; font-weight: bold">NULL</span>',
+            resp.text,
+        )
+
+    def _check_rendered__begin_rollback(self, resp):
+        self.assertIn(
+            '<span style="color: #008800; font-weight: bold">begin</span>;\n',
+            resp.text,
+        )
+        self.assertIn(
+            '<span style="color: #008800; font-weight: bold">rollback</span>;'
+            '\n',
+            resp.text,
+        )
+
+    def _check_rendered__begin_commit(self, resp):
+        self.assertIn(
+            '<span style="color: #008800; font-weight: bold">begin</span>;\n',
+            resp.text,
+        )
+        self.assertIn(
+            '<span style="color: #008800; font-weight: bold">commit</span>;\n',
+            resp.text,
+        )
+
+
+class TestNone(_TestSQLAlchemyPanel):
+    """
+    No SQLAlchemy queries
+    """
+
+    def _sqlalchemy_view(self, context, request):
+        return ok_response_factory()
+
+    def test_panel(self):
+        resp = self._makeOne()
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn(
+            '<li class="disabled" id="pDebugPanel-sqlalchemy">', resp.text
+        )
+        self.assertNotIn(
+            '<div id="pDebugPanel-sqlalchemy-content" class="panelContent" '
+            'style="display: none;">',
+            resp.text,
+        )
+
+
+class TestSimpleSelect(_TestSQLAlchemyPanel):
+    """
+    A simple SELECT
+    """
+
+    def _sqlalchemy_view(self, context, request):
+        engine = sqlalchemy.create_engine("sqlite://", isolation_level=None)
+        conn = engine.connect()
+        stmt = sqla_text("SELECT NULL;")
+        conn.execute(stmt)  # noqa
+        return ok_response_factory()
+
+    def test_panel(self):
+        resp = self._makeOne()
+        self.assertEqual(resp.status_code, 200)
+        self._check_rendered__panel(resp)
+        self._check_rendered__select_null(resp)
+
+
+class TestTransactionCommit(_TestSQLAlchemyPanel):
+    """
+    A simple transaction
+    """
+
+    def _sqlalchemy_view(self, context, request):
+        engine = sqlalchemy.create_engine("sqlite://", isolation_level=None)
+        conn = engine.connect()
+        with conn.begin():
+            stmt = sqla_text("SELECT NULL;")
+            conn.execute(stmt)  # noqa
+        return ok_response_factory()
+
+    def test_panel(self):
+        resp = self._makeOne()
+        self.assertEqual(resp.status_code, 200)
+        self._check_rendered__panel(resp)
+        self._check_rendered__select_null(resp)
+        self._check_rendered__begin_commit(resp)
+
+
+class TestTransactionRollback(_TestSQLAlchemyPanel):
+    def _sqlalchemy_view(self, context, request):
+        engine = sqlalchemy.create_engine("sqlite://", isolation_level=None)
+        conn = engine.connect()
+        try:
+            with conn.begin():
+                stmt = sqla_text("SELECT NULL;")
+                conn.execute(stmt)  # noqa
+                raise ValueError("EXPECTED")
+        except ValueError:
+            # SQLAlchemy's ContextManager will call a rollback
+            pass
+        return ok_response_factory()
+
+    def test_panel(self):
+        resp = self._makeOne()
+        self.assertEqual(resp.status_code, 200)
+        self._check_rendered__panel(resp)
+        self._check_rendered__select_null(resp)
+        self._check_rendered__begin_rollback(resp)
+
+
+class TestTransactionComplex(_TestSQLAlchemyPanel):
+    def _sqlalchemy_view(self, context, request):
+        """
+        Test to ensure the following listeners do not raise Exceptions:
+        [+] begin
+        [+] commit
+        [+] rollback
+        [+] savepoint
+        [+] rollback_savepoint
+        [+] release_savepoint
+        [+] begin_twophase
+        [ ] prepare_twophase
+        [ ] commit_twophase
+        [ ] rollback_twophase
+        """
+
+        engine = sqlalchemy.create_engine("sqlite://", isolation_level=None)
+        if not PY3 or (sys.version_info[1] <= 5):
+            # under Python2-Python3.5
+            # Sqlite needs workaround to support savepoints
+            # see https://docs.sqlalchemy.org/en/13/dialects/sqlite.html
+
+            @sqlalchemy.event.listens_for(engine, "connect")
+            def _do_connect(dbapi_connection, connection_record):
+                # disable pysqlite's emitting of the BEGIN statement entirely.
+                # also stops it from emitting COMMIT before any DDL.
+                dbapi_connection.isolation_level = None
+
+            @sqlalchemy.event.listens_for(engine, "begin")
+            def _do_begin(conn):
+                conn.execute("BEGIN")
+
+        conn = engine.connect()
+
+        # tests: `begin`, `commit`
+        t1 = conn.begin()  # `begin`
+        conn.execute(sqla_text("SELECT NULL; -- a"))
+        t1.commit()  # `commit`
+
+        # tests: `begin`, `rollback`
+        t1 = conn.begin()  # `begin`
+        conn.execute(sqla_text("SELECT NULL; -- b"))
+        t1.rollback()  # `rollback`
+
+        # tests: `begin`, `savepoint`, `rollback_savepoint`, `release_savepoint`
+        t1 = conn.begin()  # `begin`
+        conn.execute(sqla_text("SELECT NULL; -- c1"))
+        t2 = conn.begin_nested()  # `savepoint`
+        conn.execute(sqla_text("SELECT NULL; -- c2"))
+        t2.rollback()  # `rollback_savepoint`
+        t2 = conn.begin_nested()  # `savepoint`
+        conn.execute(sqla_text("SELECT NULL; -- c3"))
+        t2.commit()  # `release_savepoint`
+        conn.execute(sqla_text("SELECT NULL; -- c4"))
+        t1.commit()  # commit
+
+        # tests: `begin_twophase`
+        try:
+            conn.begin_twophase()  # `begin_twophase`
+        except NotImplementedError:
+            pass
+
+        # untested: `prepare_twophase`, `commit_twophase`, `rollback_twophase`
+
+        return ok_response_factory()
+
+    def test_panel(self):
+        resp = self._makeOne()
+        self.assertEqual(resp.status_code, 200)
+        self._check_rendered__panel(resp)

--- a/tests/test_panels/test_sqla.py
+++ b/tests/test_panels/test_sqla.py
@@ -91,23 +91,28 @@ class _TestSQLAlchemyPanel(_TestDebugtoolbarPanel):
         )
 
     def _check_rendered__begin_rollback(self, resp):
+        """
+        These are rendered as comments
+        """
         self.assertIn(
-            '<span style="color: #008800; font-weight: bold">begin</span>;\n',
+            '<span style="color: #888888">-- [event.begin]</span>',
             resp.text,
         )
         self.assertIn(
-            '<span style="color: #008800; font-weight: bold">rollback</span>;'
-            '\n',
+            '<span style="color: #888888">-- [event.rollback]</span>',
             resp.text,
         )
 
     def _check_rendered__begin_commit(self, resp):
+        """
+        These are rendered as comments
+        """
         self.assertIn(
-            '<span style="color: #008800; font-weight: bold">begin</span>;\n',
+            '<span style="color: #888888">-- [event.begin]</span>',
             resp.text,
         )
         self.assertIn(
-            '<span style="color: #008800; font-weight: bold">commit</span>;\n',
+            '<span style="color: #888888">-- [event.commit]</span',
             resp.text,
         )
 


### PR DESCRIPTION
Use the SQLAlchemy Events system to add transactional markers (such as `begin`, `commit`, `rollback`) to the debug payload

* redo of #299
* closes #236

Two things to note for code review:

1) Tests do not cover "two phase" transaction events, because Sqlite does not support them. The tests would have to run against a db like mysql, or a mocked system. I don't have the time to build out the mocked system, and adding a mysql service container is doable but questionable - so I am okay with removing these events.

2) The standard library's Sqlite driver has long had a problem with transaction levels.  The workarounds have been to:

* use the pysqlite driver
* use SQLAlchemy event listeners

I opted to use the latter option and minimize another testing include.  After some testing, the stdlib APPEARS to have resolved those issues with the Python 3.6 release, so I only deploy the connection adjustment workaround to those situations.







