### PR TITLE
Force xid conversion to string

### DIFF
--- a/src/pyramid_debugtoolbar/panels/sqla.py
+++ b/src/pyramid_debugtoolbar/panels/sqla.py
@@ -94,22 +94,22 @@ try:
 
     @event.listens_for(Engine, "begin_twophase")
     def _begin_twophase(conn, xid):
-        stmt = 'begin_twophase %s' % xid
+        stmt = 'begin_twophase %s' % str(xid)
         _transactional_event_logger(conn, stmt)
 
     @event.listens_for(Engine, "prepare_twophase")
     def _prepare_twophase(conn, xid):
-        stmt = 'prepare_twophase %s' % xid
+        stmt = 'prepare_twophase %s' % str(xid)
         _transactional_event_logger(conn, stmt)
 
     @event.listens_for(Engine, "commit_twophase")
     def _commit_twophase(conn, xid, is_prepared):
-        stmt = 'commit_twophase %s %s' % (xid, is_prepared)
+        stmt = 'commit_twophase %s %s' % (str(xid), is_prepared)
         _transactional_event_logger(conn, stmt)
 
     @event.listens_for(Engine, "rollback_twophase")
     def _rollback_twophase(conn, xid, is_prepared):
-        stmt = 'rollback_twophase %s %s' % (xid, is_prepared)
+        stmt = 'rollback_twophase %s %s' % (str(xid), is_prepared)
         _transactional_event_logger(conn, stmt)
 
     has_sqla = True


### PR DESCRIPTION
xid can be a tuple of three values when using SQLAlchemy with zope.alchemy and two-phase transactions.
Don't know how to test as two-phase transactions are not supported by SQLite...