### PR TITLE
Use current_thread instead of currentThread (deprecated)

### DIFF
--- a/src/pyramid_debugtoolbar/panels/logger.py
+++ b/src/pyramid_debugtoolbar/panels/logger.py
@@ -41,14 +41,14 @@ class ThreadTrackingHandler(logging.Handler):
         provided, returns a list for the current thread.
         """
         if thread is None:
-            thread = threading.currentThread()
+            thread = threading.current_thread()
         if thread not in self.records:
             self.records[thread] = []
         return self.records[thread]
 
     def clear_records(self, thread=None):
         if thread is None:
-            thread = threading.currentThread()
+            thread = threading.current_thread()
         if thread in self.records:
             del self.records[thread]
 


### PR DESCRIPTION
Fix for deprecation warning. See issue https://github.com/Pylons/pyramid_debugtoolbar/issues/372#issuecomment-995271942