### PR TITLE
Replace deprecated threading.currentThread with current_thread

### DIFF
--- a/src/pyramid_debugtoolbar/panels/logger.py
+++ b/src/pyramid_debugtoolbar/panels/logger.py
@@ -41,14 +41,14 @@ class ThreadTrackingHandler(logging.Handler):
         provided, returns a list for the current thread.
         """
         if thread is None:
-            thread = threading.currentThread()
+            thread = threading.current_thread()
         if thread not in self.records:
             self.records[thread] = []
         return self.records[thread]
 
     def clear_records(self, thread=None):
         if thread is None:
-            thread = threading.currentThread()
+            thread = threading.current_thread()
         if thread in self.records:
             del self.records[thread]
 


### PR DESCRIPTION
`threading.currentThread` was deprecated in Python 3.10 (October 2021).

Replace with `threading.current_thread`, added in Python 2.6 (October 2008).

* https://docs.python.org/3.12/whatsnew/3.10.html#deprecated
* https://github.com/python/cpython/pull/25174