### PR TITLE
docs: fix simple typo, attibute -> attribute

### DIFF
--- a/src/pyramid_debugtoolbar/panels/session.py
+++ b/src/pyramid_debugtoolbar/panels/session.py
@@ -27,7 +27,7 @@ class SessionDebugPanel(DebugPanel):
         """
         This is too difficult to figure out under the following parameters:
         * do not trigger the ``ISession`` interface
-        * The toolbar consults this attibute relatively early in the lifecycle
+        * The toolbar consults this attribute relatively early in the lifecycle
           to determine if ``.is_active`` should be ``True``
         """
         return True


### PR DESCRIPTION
There is a small typo in src/pyramid_debugtoolbar/panels/session.py.

Should read `attribute` rather than `attibute`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md