### PR TITLE
Add "url_scheme" setting

### DIFF
--- a/src/pyramid_debugtoolbar/__init__.py
+++ b/src/pyramid_debugtoolbar/__init__.py
@@ -38,6 +38,7 @@ default_settings = [
     ('max_request_history', as_int, 100),
     ('max_visible_requests', as_int, 10),
     ('show_on_exc_only', asbool, 'false'),
+    ('url_scheme', None, None),
 ]
 
 # We need to transform these from debugtoolbar. to pyramid. in our

--- a/src/pyramid_debugtoolbar/panels/introspection.py
+++ b/src/pyramid_debugtoolbar/panels/introspection.py
@@ -1,6 +1,6 @@
 from pyramid_debugtoolbar.panels import DebugPanel
 from pyramid_debugtoolbar.repr import debug_repr
-from pyramid_debugtoolbar.utils import STATIC_PATH
+from pyramid_debugtoolbar.utils import STATIC_PATH, get_setting
 
 try:
     from pyramid.interfaces import IIntrospector
@@ -38,7 +38,8 @@ class IntrospectionDebugPanel(DebugPanel):
         }
 
     def render_vars(self, request):
-        return {'static_path': request.static_url(STATIC_PATH)}
+        scheme = get_setting(request.registry.settings, 'scheme', None)
+        return {'static_path': request.static_url(STATIC_PATH, _scheme=scheme)}
 
 
 def nl2br(s):

--- a/src/pyramid_debugtoolbar/panels/sqla.py
+++ b/src/pyramid_debugtoolbar/panels/sqla.py
@@ -11,6 +11,7 @@ from pyramid_debugtoolbar.utils import (
     ROOT_ROUTE_NAME,
     STATIC_PATH,
     format_sql,
+    get_setting,
     text_,
 )
 
@@ -193,11 +194,12 @@ class SQLADebugPanel(DebugPanel):
         return super(SQLADebugPanel, self).render_content(request)
 
     def render_vars(self, request):
+        scheme = get_setting(request.registry.settings, 'url_scheme', None)
         return {
             'pdtb_id': self.pdtb_id,
             'route_url': request.route_url,
-            'static_path': request.static_url(STATIC_PATH),
-            'root_path': request.route_url(ROOT_ROUTE_NAME),
+            'static_path': request.static_url(STATIC_PATH, _scheme=scheme),
+            'root_path': request.route_url(ROOT_ROUTE_NAME, _scheme=scheme),
         }
 
 

--- a/src/pyramid_debugtoolbar/panels/traceback.py
+++ b/src/pyramid_debugtoolbar/panels/traceback.py
@@ -9,6 +9,7 @@ from pyramid_debugtoolbar.utils import (
     ROOT_ROUTE_NAME,
     STATIC_PATH,
     escape,
+    get_setting,
 )
 
 _ = lambda x: x
@@ -54,12 +55,15 @@ class TracebackPanel(DebugPanel):
 
     def render_vars(self, request):
         vars = self.data.copy()
+        scheme = get_setting(request.registry.settings, 'url_scheme', None)
         vars.update(
             {
-                'static_path': request.static_url(STATIC_PATH),
-                'root_path': request.route_url(ROOT_ROUTE_NAME),
+                'static_path': request.static_url(STATIC_PATH, _scheme=scheme),
+                'root_path':
+                    request.route_url(ROOT_ROUTE_NAME, _scheme=scheme),
                 'url': request.route_url(
-                    EXC_ROUTE_NAME, request_id=request.pdtb_id
+                    EXC_ROUTE_NAME, request_id=request.pdtb_id,
+                    _scheme=scheme,
                 ),
                 # render the summary using the toolbar's request object, not
                 # the original request that generated the traceback!

--- a/src/pyramid_debugtoolbar/panels/tweens.py
+++ b/src/pyramid_debugtoolbar/panels/tweens.py
@@ -1,7 +1,7 @@
 from pyramid.interfaces import ITweens
 
 from pyramid_debugtoolbar.panels import DebugPanel
-from pyramid_debugtoolbar.utils import STATIC_PATH
+from pyramid_debugtoolbar.utils import STATIC_PATH, get_setting
 
 _ = lambda x: x
 
@@ -37,7 +37,8 @@ class TweensDebugPanel(DebugPanel):
         }
 
     def render_vars(self, request):
-        return {'static_path': request.static_url(STATIC_PATH)}
+        scheme = get_setting(request.registry.settings, 'url_scheme', None)
+        return {'static_path': request.static_url(STATIC_PATH, _scheme=scheme)}
 
 
 def includeme(config):

--- a/src/pyramid_debugtoolbar/tbtools.py
+++ b/src/pyramid_debugtoolbar/tbtools.py
@@ -32,6 +32,7 @@ from pyramid_debugtoolbar.utils import (
     ROOT_ROUTE_NAME,
     STATIC_PATH,
     escape,
+    get_setting,
 )
 
 # Some regexes are binary strings because they are used for determining the
@@ -280,12 +281,14 @@ class Traceback(object):
 
     def render_full(self, request, lodgeit_url=None):
         """Render the Full HTML page with the traceback info."""
-        static_path = request.static_url(STATIC_PATH)
-        root_path = request.route_url(ROOT_ROUTE_NAME)
+        scheme = get_setting(request.registry.settings, 'url_scheme', None)
+        static_path = request.static_url(STATIC_PATH, _scheme=scheme)
+        root_path = request.route_url(ROOT_ROUTE_NAME, _scheme=scheme)
         exc = escape(self.exception)
         summary = self.render_summary(include_title=False, request=request)
         token = request.registry.parent_registry.pdtb_token
-        url = request.route_url(EXC_ROUTE_NAME, request_id=request.pdtb_id)
+        url = request.route_url(
+            EXC_ROUTE_NAME, request_id=request.pdtb_id, _scheme=scheme)
         evalex = request.registry.parent_registry.pdtb_eval_exc
         vars = {
             'evalex': evalex and 'true' or 'false',

--- a/src/pyramid_debugtoolbar/toolbar.py
+++ b/src/pyramid_debugtoolbar/toolbar.py
@@ -121,7 +121,8 @@ class DebugToolbar(object):
             request.registry.settings, 'button_style', ''
         )
         css_path = request.static_url(
-            STATIC_PATH + 'toolbar/toolbar_button.css'
+            STATIC_PATH + 'toolbar/toolbar_button.css',
+            _scheme=get_setting(request.registry.settings, 'url_scheme', None),
         )
         toolbar_html = toolbar_html_template % {
             'button_style': (

--- a/src/pyramid_debugtoolbar/toolbar_app.py
+++ b/src/pyramid_debugtoolbar/toolbar_app.py
@@ -161,8 +161,9 @@ def request_view(request):
             panel.name: panel for panel in toolbar.panels
         }
 
-    static_path = request.static_url(STATIC_PATH)
-    root_path = request.route_url(ROOT_ROUTE_NAME)
+    scheme = get_setting(request.registry.settings, 'url_scheme', None)
+    static_path = request.static_url(STATIC_PATH, _scheme=scheme)
+    root_path = request.route_url(ROOT_ROUTE_NAME, _scheme=scheme)
 
     button_style = get_setting(request.registry.settings, 'button_style')
     max_visible_requests = get_setting(

--- a/src/pyramid_debugtoolbar/utils.py
+++ b/src/pyramid_debugtoolbar/utils.py
@@ -214,7 +214,9 @@ def addr_in(addr, hosts):
 
 
 def debug_toolbar_url(request, *elements, **kw):
-    return request.route_url('debugtoolbar', subpath=elements, **kw)
+    scheme = get_setting(request.registry.settings, 'url_scheme', None)
+    return request.route_url(
+        'debugtoolbar', subpath=elements, _scheme=scheme, **kw)
 
 
 def hexlify(value):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -65,6 +65,7 @@ class Test_parse_settings(unittest.TestCase):
                 'debugtoolbar.button_style': '',
                 'debugtoolbar.max_request_history': 100,
                 'debugtoolbar.max_visible_requests': 10,
+                'debugtoolbar.url_scheme': None,
             },
         )
 


### PR DESCRIPTION
I imagine it is common to have the pyramid process behind a reverse proxy or load balancer that is accessed via HTTPS by the user. This is my case and debugtoolbar is generating urls using the HTTP scheme without this change and therefore the browser refuses to load static assets.