### PR TITLE
Use SQLAlchemy 2.x execution API

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -77,6 +77,19 @@ jobs:
             - run: pip install tox
             - name: Running tox
               run: tox -e py37-pyramid19
+    test-sqlalchemy14:
+      runs-on: ubuntu-latest
+      name: "Python: 3.11-x64 on ubuntu-latest with SQLAlchemy 1.4"
+      steps:
+            - uses: actions/checkout@v4
+            - name: Setup python
+              uses: actions/setup-python@v4
+              with:
+                  python-version: 3.11
+                  architecture: x64
+            - run: pip install tox
+            - name: Running tox
+              run: tox -e py311-sqlalchemy14
     coverage:
         runs-on: ubuntu-latest
         name: Validate coverage

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -125,3 +125,4 @@ Contributors
 - Marcin Lulek, 2018-02-19
 - Wim De Clercq, 2018-11-23
 - Holger Peters, 2020-02-06
+- Nicholas Pilon, 2024-01-05

--- a/demo/sqla.py
+++ b/demo/sqla.py
@@ -1,7 +1,6 @@
 from pyramid.view import view_config
 
-from sqlalchemy import create_engine
-from sqlalchemy import MetaData
+from sqlalchemy import MetaData, create_engine, text
 from sqlalchemy import Table, Column, Integer, String
 from sqlalchemy.pool import StaticPool
 
@@ -14,32 +13,32 @@ users_table = Table(
 )
 
 def initialize_sql(settings):
-    engine = create_engine('sqlite://',
-            connect_args={'check_same_thread':False},
-            poolclass=StaticPool,
-            echo=True)
+    engine = create_engine(
+        'sqlite://',
+        connect_args={'check_same_thread':False},
+        poolclass=StaticPool,
+        echo=True,
+    )
     settings['engine'] = engine
-
-    try:
-        populate_db(engine)
-    except:
-        pass
+    populate_db(engine)
 
 def populate_db(engine):
     meta.create_all(bind=engine)
 
-    users = ('blaflamme', 'mcdonc', 'mmerickel')
-    try:
+    with engine.connect() as conn:
+        users = ('blaflamme', 'mcdonc', 'mmerickel')
         for i, user in enumerate(users):
-            engine.execute('insert into users (id, name) values (:id, :name)',
-                    id=i, name=user)
-    except:
-        pass
+            conn.execute(
+                text('insert into users (id, name) values (:id, :name)'),
+                {'id': i, 'name': user},
+            )
+        conn.commit()
 
 @view_config(route_name='test_sqla', renderer='__main__:templates/sqla.mako')
 def test_sqla(request):
     engine = request.registry.settings['engine']
-    users = engine.execute('select * from users')
+    with engine.connect() as conn:
+        users = conn.execute(text('select * from users')).all()
     return {
         'title':'Test SQLAlchemy logging',
         'users':users,

--- a/src/pyramid_debugtoolbar/panels/sqla.py
+++ b/src/pyramid_debugtoolbar/panels/sqla.py
@@ -229,11 +229,11 @@ class SQLAlchemyViews(object):
 
         engines = self.request.registry.parent_registry.pdtb_sqla_engines
         engine = engines[int(engine_id)]()
-        with engine.connect() as connection:
-            result = connection.exec_driver_sql(stmt, params)
+        with engine.connect() as conn:
+            result = conn.exec_driver_sql(stmt, params)
 
             return {
-                'result': result.fetchall(),
+                'result': result.all(),
                 'headers': result.keys(),
                 'sql': format_sql(stmt),
                 'duration': float(query_dict['duration']),
@@ -262,11 +262,11 @@ class SQLAlchemyViews(object):
         else:
             query = 'EXPLAIN %s' % stmt
 
-        with engine.connect() as connection:
-            result = connection.exec_driver_sql(query, params)
+        with engine.connect() as conn:
+            result = conn.exec_driver_sql(query, params)
 
             return {
-                'result': result.fetchall(),
+                'result': result.all(),
                 'headers': result.keys(),
                 'sql': format_sql(stmt),
                 'str': str,

--- a/src/pyramid_debugtoolbar/panels/sqla.py
+++ b/src/pyramid_debugtoolbar/panels/sqla.py
@@ -229,14 +229,15 @@ class SQLAlchemyViews(object):
 
         engines = self.request.registry.parent_registry.pdtb_sqla_engines
         engine = engines[int(engine_id)]()
-        result = engine.execute(stmt, params)
+        with engine.connect() as connection:
+            result = connection.exec_driver_sql(stmt, params)
 
-        return {
-            'result': result.fetchall(),
-            'headers': result.keys(),
-            'sql': format_sql(stmt),
-            'duration': float(query_dict['duration']),
-        }
+            return {
+                'result': result.fetchall(),
+                'headers': result.keys(),
+                'sql': format_sql(stmt),
+                'duration': float(query_dict['duration']),
+            }
 
     @view_config(
         route_name='debugtoolbar.sql_explain',
@@ -261,15 +262,16 @@ class SQLAlchemyViews(object):
         else:
             query = 'EXPLAIN %s' % stmt
 
-        result = engine.execute(query, params)
+        with engine.connect() as connection:
+            result = connection.exec_driver_sql(query, params)
 
-        return {
-            'result': result.fetchall(),
-            'headers': result.keys(),
-            'sql': format_sql(stmt),
-            'str': str,
-            'duration': float(query_dict['duration']),
-        }
+            return {
+                'result': result.fetchall(),
+                'headers': result.keys(),
+                'sql': format_sql(stmt),
+                'str': str,
+                'duration': float(query_dict['duration']),
+            }
 
 
 def includeme(config):

--- a/tests/test_panels/_utils.py
+++ b/tests/test_panels/_utils.py
@@ -18,7 +18,6 @@ def ok_response_factory():
 
 
 class _TestDebugtoolbarPanel(unittest.TestCase):
-
     re_toolbar_link = re_toolbar_link
 
     def setUp(self):

--- a/tests/test_panels/test_request_vars.py
+++ b/tests/test_panels/test_request_vars.py
@@ -35,7 +35,6 @@ def templated_escaped(input, expect_saferepr=None):
 
 class _TestPanel_RequestVars(_TestDebugtoolbarPanel):
     def _makeOne(self, query_args=None, post_body=None, content_type=None):
-
         # make a request
         query_args = ("?=%s" % urlencode(query_args)) if query_args else ""
         kwargs = {}

--- a/tests/test_panels/test_sqla.py
+++ b/tests/test_panels/test_sqla.py
@@ -138,9 +138,9 @@ class TestSimpleSelect(_TestSQLAlchemyPanel):
 
     def _sqlalchemy_view(self, context, request):
         engine = sqlalchemy.create_engine("sqlite://", isolation_level=None)
-        conn = engine.connect()
-        stmt = sqla_text("SELECT NULL;")
-        conn.execute(stmt)  # noqa
+        with engine.begin() as conn:
+            stmt = sqla_text("SELECT NULL;")
+            conn.execute(stmt)  # noqa
         return ok_response_factory()
 
     def test_panel(self):
@@ -157,8 +157,7 @@ class TestTransactionCommit(_TestSQLAlchemyPanel):
 
     def _sqlalchemy_view(self, context, request):
         engine = sqlalchemy.create_engine("sqlite://", isolation_level=None)
-        conn = engine.connect()
-        with conn.begin():
+        with engine.begin() as conn:
             stmt = sqla_text("SELECT NULL;")
             conn.execute(stmt)  # noqa
         return ok_response_factory()
@@ -174,9 +173,8 @@ class TestTransactionCommit(_TestSQLAlchemyPanel):
 class TestTransactionRollback(_TestSQLAlchemyPanel):
     def _sqlalchemy_view(self, context, request):
         engine = sqlalchemy.create_engine("sqlite://", isolation_level=None)
-        conn = engine.connect()
         try:
-            with conn.begin():
+            with engine.begin() as conn:
                 stmt = sqla_text("SELECT NULL;")
                 conn.execute(stmt)  # noqa
                 raise ValueError("EXPECTED")

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ deps =
     pyramid18: pyramid <= 1.8.99
     pyramid19: pyramid <= 1.9.99
     pyramid110: pyramid <= 1.10.99
-    sqlalchemy14: sqlalchemy <= 1.4
+    sqlalchemy14: sqlalchemy < 2.0
     sqlalchemy20: sqlalchemy >= 2.0, <2.1
 
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,8 @@ deps =
     pyramid18: pyramid <= 1.8.99
     pyramid19: pyramid <= 1.9.99
     pyramid110: pyramid <= 1.10.99
+    sqlalchemy14: sqlalchemy <= 1.4
+    sqlalchemy20: sqlalchemy >= 2.0, <2.1
 
 commands =
     py.test --cov --cov-report= {posargs:}


### PR DESCRIPTION
SQLAlchemy 2.0 [removes the "connectionless" execution option](https://docs.sqlalchemy.org/en/14/changelog/migration_20.html#implicit-and-connectionless-execution-bound-metadata-removed) and requires the use of a new context manager [connection API](https://docs.sqlalchemy.org/en/14/changelog/migration_20.html#migration-core-connection-transaction). This pull request adjusts the pyramid debugtoolbar SQLAlchemy panel to use this new style.

- I don't think this new style will work with sqlalchemy older than 1.4; how should that be handled?
- `connection.execute()` expects a different bind-param style than is generated here; `exec_driver_sql` worked for me with psycopg2, but I'm not sure if it's correct for other drivers.