### PR TITLE
drop setuptools / pkg_resources

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,6 +2,7 @@ unreleased
 ----------
 
 - Remove dependency on setuptools / pkg_resources.
+  See https://github.com/Pylons/pyramid_debugtoolbar/pull/390
 
 4.11 (2024-01-27)
 -----------------

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,8 @@
+unreleased
+----------
+
+- Remove dependency on setuptools / pkg_resources.
+
 4.11 (2024-01-27)
 -----------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,9 +17,13 @@
 #sys.path.append(os.path.abspath('some/directory'))
 
 import datetime
-import pkg_resources
 import pylons_sphinx_themes
 import sys, os
+
+try:
+    import importlib.metadata as metadata
+except ImportError:
+    import importlib_metadata as metadata
 
 # General configuration
 # ---------------------
@@ -54,7 +58,7 @@ copyright = '2012-%s, Agendaless Consulting' % thisyear
 # other places throughout the built documents.
 #
 # The short X.Y version.
-version = pkg_resources.get_distribution('pyramid_debugtoolbar').version
+version = metadata.distribution('pyramid_debugtoolbar').version
 
 # The full version, including alpha/beta/rc tags.
 release = version

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,7 @@ install_requires =
     pyramid>=1.4
     pyramid_mako>=0.3.1
     Pygments
+    importlib-metadata; python_version<"3.8"
 include_package_data = True
 python_requires = >=3.7
 
@@ -54,5 +55,3 @@ testing =
 docs =
     Sphinx >= 1.7.5
     pylons-sphinx-themes >= 0.3
-    # need pkg_resources in docs/conf.py
-    setuptools

--- a/src/pyramid_debugtoolbar/panels/templates/versions.dbtmako
+++ b/src/pyramid_debugtoolbar/panels/templates/versions.dbtmako
@@ -8,7 +8,7 @@
 		<tr>
 			<th>Package Name</th>
 			<th>Version</th>
-			<th>Location</th>
+			<th>Summary</th>
 		</tr>
 	</thead>
 	<tbody>
@@ -16,7 +16,7 @@
 			<tr>
 				<td>${package['name']|h}</td>
 				<td>${package['version']|h}</td>
-				<td>${package['location']|h}</td>
+				<td>${package['summary']|h}</td>
 			</tr>
 		% endfor
 	</tbody>

--- a/src/pyramid_debugtoolbar/panels/versions.py
+++ b/src/pyramid_debugtoolbar/panels/versions.py
@@ -1,26 +1,30 @@
 from operator import itemgetter
-import pkg_resources
 import platform
 import sys
 
 from pyramid_debugtoolbar.panels import DebugPanel
 
+try:
+    import importlib.metadata as metadata
+except ImportError:
+    import importlib_metadata as metadata
+
 _ = lambda x: x
 
 packages = []
-for distribution in pkg_resources.working_set:
-    name = distribution.project_name
+for distribution in metadata.distributions():
+    name = distribution.metadata['Name']
     packages.append(
         {
             'version': distribution.version,
-            'location': distribution.location,
+            'summary': distribution.metadata.get('Summary'),
             'lowername': name.lower(),
             'name': name,
         }
     )
 
 packages = sorted(packages, key=itemgetter('lowername'))
-pyramid_version = pkg_resources.get_distribution('pyramid').version
+pyramid_version = metadata.distribution('pyramid').version
 
 
 class VersionDebugPanel(DebugPanel):


### PR DESCRIPTION
sadly importlib.metadata does not make it possible to get the location of a package since it's trying to abstract that detail now... we could detect a PathDistribution but that's a private api and doesn't seem worth it.