### PR TITLE
fix inadvertent deprecation warnings triggered by using the toolbar

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,10 @@ unreleased
 - Remove dependency on setuptools / pkg_resources.
   See https://github.com/Pylons/pyramid_debugtoolbar/pull/390
 
+- Avoid triggering DeprecationWarnings when tracking values for
+  deprecated attributes in Pyramid like ``effective_principals``.
+  See https://github.com/Pylons/pyramid_debugtoolbar/pull/391
+
 4.11 (2024-01-27)
 -----------------
 

--- a/src/pyramid_debugtoolbar/__init__.py
+++ b/src/pyramid_debugtoolbar/__init__.py
@@ -153,20 +153,11 @@ def _apply_parent_actions(parent_registry):
 
     toolbar_registry = toolbar_app.registry
 
-    # inject the BeforeRender subscriber after the application is created
-    # and all other subscribers are registered in hopes that this will be
-    # the last subscriber in the chain and will be able to see the effects
-    # of all previous subscribers on the event
     parent_config = Configurator(registry=parent_registry, introspection=False)
-
-    parent_config.add_subscriber(
-        'pyramid_debugtoolbar.toolbar.beforerender_subscriber',
-        'pyramid.events.BeforeRender',
-    )
-
     actions = toolbar_registry.queryUtility(IParentActions, default=[])
     for action in actions:
         action(parent_config)
+        parent_config.commit()
 
     # overwrite actions after they have been applied to avoid applying them
     # twice - but leave it as a new list incase someone adds more actions later
@@ -174,6 +165,14 @@ def _apply_parent_actions(parent_registry):
     # for tests that call config.make_wsgi_app() multiple times.
     toolbar_registry.registerUtility([], IParentActions)
 
+    # inject the BeforeRender subscriber after the application is created
+    # and all other subscribers are registered in hopes that this will be
+    # the last subscriber in the chain and will be able to see the effects
+    # of all previous subscribers on the event
+    parent_config.add_subscriber(
+        'pyramid_debugtoolbar.toolbar.beforerender_subscriber',
+        'pyramid.events.BeforeRender',
+    )
     parent_config.commit()
 
 

--- a/src/pyramid_debugtoolbar/panels/request_vars.py
+++ b/src/pyramid_debugtoolbar/panels/request_vars.py
@@ -1,7 +1,5 @@
 from pprint import saferepr
 
-from pyramid.interfaces import IRequestFactory
-from pyramid.request import Request
 from pyramid_debugtoolbar.panels import DebugPanel
 from pyramid_debugtoolbar.utils import dictrepr, patch_attrs
 
@@ -148,7 +146,8 @@ class RequestVarsDebugPanel(DebugPanel):
 
     def process_response(self, response):
         extracted_attributes = extract_request_attributes(
-            self.request, self.accessed_attrs)
+            self.request, self.accessed_attrs
+        )
         self.data['extracted_attributes'].update(extracted_attributes)
 
         # stop hanging onto the request after the response is processed


### PR DESCRIPTION
- The toolbar has been triggering a deprecation warning due to its incorrect wrapping of request.effective_principals.