### PR TITLE
Don't fail on non-str, non-bytes __traceback_info__

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -126,3 +126,4 @@ Contributors
 - Wim De Clercq, 2018-11-23
 - Holger Peters, 2020-02-06
 - Nicholas Pilon, 2024-01-05
+- Adrian Heine, 2025-02-14

--- a/src/pyramid_debugtoolbar/tbtools.py
+++ b/src/pyramid_debugtoolbar/tbtools.py
@@ -334,7 +334,7 @@ class Frame(object):
         self.hide = self.locals.get('__traceback_hide__', False)
         info = self.locals.get('__traceback_info__')
         if info is not None:
-            info = str(info, errors='replace')
+            info = str(info, errors='replace') if isinstance(info, bytes) else info
         self.info = info
 
     def render(self):


### PR DESCRIPTION
In 1c050afa8c839ac73f9d96fbb1034a7910ce8a74, 

```py
            info = text_(info, errors='replace')
```

was replaced by

```py
            info = str(info, errors='replace')
```

with `_text` being:

```py
if PY3:  # pragma: no cover
    # […]
    binary_type = bytes
    # […]
else:
    # […]
    binary_type = str
    # […]

# […]

def text_(s, encoding='latin-1', errors='strict'):
    if isinstance(s, binary_type):
        return s.decode(encoding, errors)
    return s  # pragma: no cover
```

This broke all cases of `__traceback_info__` being something else than a `str` or a `bytes`, [given that](https://docs.python.org/3/library/stdtypes.html#str) 
> If at least one of encoding or errors is given, object should be a [bytes-like object](https://docs.python.org/3/glossary.html#term-bytes-like-object) (e.g. [bytes](https://docs.python.org/3/library/stdtypes.html#bytes) or [bytearray](https://docs.python.org/3/library/stdtypes.html#bytearray)).